### PR TITLE
Fix builder deployment modality script syntax

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,12 +11,31 @@
         body { font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif; background-color: #f5f7f9; padding: 40px; }
         .maker-container { max-width: 1200px; margin: 0 auto; background: white; box-shadow: 0 0 20px rgba(0, 0, 0, 0.1); border-radius: 12px; padding: 30px; }
         .maker-header { text-align: center; margin-bottom: 30px; border-bottom: 1px solid #e9ecef; padding-bottom: 20px; }
-        .subsection-item { display: flex; align-items: center; gap: 10px; margin-bottom: 15px; }
-        .subsection-item input, .subsection-item textarea { flex-grow: 1; }
+        .deployment-modalities-card .card-header { display: flex; flex-direction: column; gap: 4px; }
+        .deployment-modalities-options { display: flex; flex-wrap: wrap; gap: 12px; }
+        .modality-option { border: 1px solid #d0d7ff; border-radius: 50px; padding: 10px 18px; display: flex; align-items: center; gap: 10px; cursor: pointer; transition: all 0.2s ease; background: #f8f9ff; }
+        .modality-option:hover { box-shadow: 0 6px 16px rgba(99, 102, 241, 0.15); transform: translateY(-2px); }
+        .modality-option input { display: none; }
+        .modality-option .modality-icon { width: 28px; height: 28px; border-radius: 50%; display: flex; align-items: center; justify-content: center; color: white; font-size: 0.9rem; }
+        .modality-option .modality-label { font-weight: 600; color: #1f2937; }
+        .modality-option.embedded .modality-icon { background: linear-gradient(135deg, #2563eb, #3b82f6); }
+        .modality-option.coupled .modality-icon { background: linear-gradient(135deg, #f59e0b, #fbbf24); }
+        .modality-option.self-sustained .modality-icon { background: linear-gradient(135deg, #16a34a, #22c55e); }
+        .modality-option.selected { border-color: transparent; background: linear-gradient(135deg, rgba(79, 70, 229, 0.08), rgba(129, 140, 248, 0.08)); }
+        .subsection-item { display: flex; align-items: flex-start; gap: 10px; margin-bottom: 15px; }
+        .subsection-item .rich-text-editor { flex: 1; }
+        .section-content-editor { margin-top: 10px; }
+        .section-content-editor .editor-content { min-height: 160px; }
         .weight-input { width: 100px; }
         .accordion-button:not(.collapsed) { color: #fff; background-color: #0d6efd; }
         .accordion-button:not(.collapsed)::after { filter: brightness(0) invert(1); }
         .section-header-controls { display: flex; align-items: center; gap: 15px; }
+        .rich-text-editor { flex-grow: 1; }
+        .editor-toolbar { display: flex; flex-wrap: wrap; gap: 6px; margin-bottom: 8px; }
+        .editor-toolbar .btn { padding: 4px 8px; }
+        .editor-content { border: 1px solid #ced4da; border-radius: 8px; min-height: 80px; padding: 10px; background-color: #fff; transition: border-color 0.2s ease, box-shadow 0.2s ease; }
+        .editor-content:focus, .editor-content.focus { outline: none; border-color: #0d6efd; box-shadow: 0 0 0 0.25rem rgba(13, 110, 253, 0.25); }
+        .editor-content.empty::before { content: attr(data-placeholder); color: #6c757d; pointer-events: none; }
     </style>
 </head>
 <body>
@@ -24,6 +43,16 @@
         <div class="maker-header">
             <h2>🛠️ Creador Avanzado de Herramientas de Evaluación</h2>
             <p class="text-muted">Personaliza cada aspecto de tu herramienta. El HTML generado será 100% funcional e idéntico al original.</p>
+        </div>
+
+        <div class="card my-4 deployment-modalities-card" id="deployment-modalities-card">
+            <div class="card-header">
+                <h5 class="mb-0">Supported Deployment Modalities</h5>
+                <small class="text-muted">Select the deployment profiles your SCT can support.</small>
+            </div>
+            <div class="card-body">
+                <div class="deployment-modalities-options" id="deployment-modalities-options"></div>
+            </div>
         </div>
 
         <div class="card my-4">
@@ -44,10 +73,18 @@
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
 
     <script>
+    const DEPLOYMENT_MODALITIES = [
+        { key: 'embedded', label: 'Embedded', icon: 'fa-hospital', accentClass: 'embedded' },
+        { key: 'coupled', label: 'Coupled', icon: 'fa-link', accentClass: 'coupled' },
+        { key: 'self-sustained', label: 'Self-Sustained', icon: 'fa-campground', accentClass: 'self-sustained' }
+    ];
+
+    let builderSelectedModalities = new Set(DEPLOYMENT_MODALITIES.map(modality => modality.key));
+
     const TOOL_CONFIG = {
-        'info': { title: 'INFO', icon: 'fa-info-circle', hasSubsections: false, weight: 0, enabled: true },
-        'definition': { title: 'DEFINITION', icon: 'fa-book', hasSubsections: false, weight: 0, enabled: true },
-        'org-detail': { title: 'ORGANIZATIONAL DETAIL', icon: 'fa-building', hasSubsections: false, weight: 0, enabled: true },
+        'info': { title: 'INFO', icon: 'fa-info-circle', hasSubsections: false, weight: 0, enabled: true, editableContent: true },
+        'definition': { title: 'DEFINITION', icon: 'fa-book', hasSubsections: false, weight: 0, enabled: true, editableContent: true },
+        'org-detail': { title: 'ORGANIZATIONAL DETAIL', icon: 'fa-building', hasSubsections: false, weight: 0, enabled: true, editableContent: true },
         'guiding-principles': { title: 'GUIDING PRINCIPLES', icon: 'fa-star', hasSubsections: true, weight: 2, enabled: true, subsections: ['Safe Care - Written statement on behalf the organization', 'Equitable Care - Written statement on behalf the organization', 'Ethical Care - Written statement on behalf the organization', 'Accountable Response - Written statement on behalf the organization', 'Appropriate Response - Written statement on behalf the organization', 'Coordinated Response - Written statement on behalf the organization'] },
         'core-standards': { title: 'CORE STANDARDS', icon: 'fa-cogs', hasSubsections: true, weight: 18, enabled: true, subsections: ['Administration & Organizational Management', 'Human Resources', 'Professional Licensing & Conduct', 'Training of Teams', 'Coordination of EMTs', 'Records and Reporting'] },
         'clinical-standards': { 
@@ -69,17 +106,172 @@
                 '<strong>Distribution</strong> - Distribute ORS sachets and water treatment products'
             ]
         },
-        'logistic-standards': { title: 'LOGISTIC STANDARDS', icon: 'fa-truck', hasSubsections: true, weight: 10, enabled: true, subsections: ['Power and Fuel - SCTs/EMTs must ensure sufficient power supply', 'Communications - SCTs/EMTs must have communication capabilities', 'Transportation & Fleet', 'Warehouse Management'] },
-        'wash-standards': { title: 'WASH STANDARDS', icon: 'fa-hand-holding-water', hasSubsections: true, weight: 10, enabled: true, subsections: ['Water Supply - SCTs/EMTs must ensure sufficient safe drinking water', 'Hygiene - SCTs/EMTs must ensure safe hygiene measures', 'Environmental Cleaning', 'Healthcare Waste Management'] },
+        'logistic-standards': {
+            title: 'LOGISTIC STANDARDS', icon: 'fa-truck', hasSubsections: true, weight: 10, enabled: true,
+            subsections: [
+                'Power and Fuel: EMTs must ensure sufficient, safe, sustainable and context appropriate fuel, power supply and lighting for their facilities, clinical care and support services.',
+                'Communications: EMTs must have the ability to transmit by voice and data to the local and national coordination structures with at least one level of redundancy in case of failure.',
+                'Transportation and fleet: EMTs must effectively coordinate the transportation of equipment and personnel to the scene and throughout the deployment.',
+                'Food: EMTs must provide food requirements for all staff, inpatients and caregivers.',
+                'Warehouse Management: EMTs have warehouse management processes and procedures that address preparedness requirements and an ability to respond in the field to manage consistent availability of supplies.',
+                'Pharmacy supply chain and medical stock Management: EMTs are self-sufficient with enough pharmaceutical, medical consumables and medical equipment to deliver patient care.',
+                'Donation Management: EMTs should have policies in place compliant with national and international standards, for anticipated donation of medical consumables, pharmaceuticals, equipment and/or their entire field facility.',
+                'Safety and security: EMTs must demonstrate due diligence for the safety and security of their personnel and patients during deployment by putting in place management plans and practical measures appropriate to the operational context and communicate plans to those concerned.',
+                'Facility structure, environment & ventilation: EMTs must be able to provide suitable and acceptable facilities for clinical care and staff needs.',
+                'Site assessment and planning: EMTs are able to assess possible site locations and adapt their configuration to local conditions, including the possibility to work within or reinforce existing health facilities.',
+                'Sequential build: EMTs must prioritize the establishment of their facility in a way that areas and services necessary for urgent patient care are established first while the rest of the facility is completed, allowing certain functions to be operational before deployment is fully completed.',
+                'Mobilization: EMTs must be able to mobilize in the shortest possible time ensuring general and institutional interventions to support their operational readiness status.',
+                'Demobilization: EMTs should have plans and procedures for coordinated demobilization that maximizes the time of operation and minimizes disruption, supporting recovery of normal local health services and local environmental impacts.'
+            ]
+        },
+        'wash-standards': {
+            title: 'WASH STANDARDS', icon: 'fa-hand-holding-water', hasSubsections: true, weight: 10, enabled: true,
+            subsections: [
+                'Water Supply: EMTs must ensure that patients, caregivers and staff have sufficient safe drinking water at all times, distributed through appropriate water collection points and facilities, to enable medical, personal hygiene, drinking, cooking, cleaning and laundry activities.',
+                'Hygiene: EMTs should ensure that staff and patients can practice hand hygiene throughout the facility by promoting access to culturally appropriate materials and places for handwashing, as well as adequate access to showers, safe spaces and materials for personal and menstrual hygiene.',
+                'Environmental cleaning: EMT facilities and the immediate environment should always be kept clean and hygienic. EMTs should have documented procedures and appropriate materials for immediate, routine and terminal cleaning to reduce risks of infection.',
+                'Healthcare Waste Management: EMTs are responsible for the safe management and disposal of health waste generated at their facilities. Safe health-care waste management involves multiple steps: minimization, segregation, collection, storage, treatment and final disposal.',
+                'Sanitation: EMTs must ensure that patients, staff and caregivers have accessible, appropriate, safe and sufficient facilities and well-documented procedures in place for management of excreta and grey and storm water to limit disease transmission.',
+                'Vector and Pest Control: EMTs should ensure that patients, staff and caregivers are protected from disease vectors and pests by using appropriate equipment and methods adapted to the local context.',
+                'Dead Body Management: EMTs need to be able to manage dead bodies in a way that is dignified, culturally appropriate, safe and according to public health practices.'
+            ]
+        },
         'summary': { title: 'SUMMARY', icon: 'fa-file-alt', hasSubsections: false, weight: 0, enabled: true }
     };
+
+    let activeEditor = null;
+    let savedRange = null;
+    const SECTION_CONTENT = {};
+
+    function storeSelection(editor) {
+        const selection = window.getSelection();
+        if (!selection || selection.rangeCount === 0) return;
+        const range = selection.getRangeAt(0);
+        if (editor && editor.contains(range.commonAncestorContainer)) {
+            savedRange = range.cloneRange();
+        }
+    }
+
+    function restoreSelection(editor) {
+        if (!savedRange || !editor || !editor.contains(savedRange.commonAncestorContainer)) {
+            savedRange = null;
+            editor?.focus();
+            return;
+        }
+        const selection = window.getSelection();
+        selection.removeAllRanges();
+        selection.addRange(savedRange);
+        editor.focus();
+    }
+
+    function renderDeploymentModalitiesSelector() {
+        const container = document.getElementById('deployment-modalities-options');
+        if (!container) return;
+        container.innerHTML = '';
+        DEPLOYMENT_MODALITIES.forEach(modality => {
+            const isChecked = builderSelectedModalities.has(modality.key);
+            container.insertAdjacentHTML('beforeend', `
+                <label class="modality-option ${modality.accentClass} ${isChecked ? 'selected' : ''}" data-key="${modality.key}">
+                    <input type="checkbox" class="deployment-modality-checkbox" data-key="${modality.key}" ${isChecked ? 'checked' : ''}>
+                    <span class="modality-icon"><i class="fas ${modality.icon}"></i></span>
+                    <span class="modality-label">${modality.label}</span>
+                </label>
+            `);
+        });
+
+        container.querySelectorAll('.deployment-modality-checkbox').forEach(input => {
+            input.onchange = (event) => {
+                const key = event.currentTarget.dataset.key;
+                if (event.currentTarget.checked) {
+                    builderSelectedModalities.add(key);
+                } else {
+                    builderSelectedModalities.delete(key);
+                }
+                const label = event.currentTarget.closest('.modality-option');
+                if (label) {
+                    label.classList.toggle('selected', event.currentTarget.checked);
+                }
+            };
+        });
+    }
+
+    function getEditorTemplate(content = '', placeholder = 'Describe el estándar...') {
+        return `
+            <div class="rich-text-editor">
+                <div class="editor-toolbar">
+                    <button type="button" class="btn btn-outline-secondary btn-sm format-btn" data-command="bold" title="Negrita"><i class="fas fa-bold"></i></button>
+                    <button type="button" class="btn btn-outline-secondary btn-sm format-btn" data-command="italic" title="Cursiva"><i class="fas fa-italic"></i></button>
+                    <button type="button" class="btn btn-outline-secondary btn-sm format-btn" data-command="underline" title="Subrayado"><i class="fas fa-underline"></i></button>
+                    <button type="button" class="btn btn-outline-secondary btn-sm format-btn" data-command="insertUnorderedList" title="Lista con viñetas"><i class="fas fa-list-ul"></i></button>
+                    <button type="button" class="btn btn-outline-secondary btn-sm format-btn" data-command="insertOrderedList" title="Lista numerada"><i class="fas fa-list-ol"></i></button>
+                    <button type="button" class="btn btn-outline-secondary btn-sm format-btn" data-command="removeFormat" title="Limpiar formato"><i class="fas fa-eraser"></i></button>
+                </div>
+                <div class="editor-content form-control" contenteditable="true" data-placeholder="${placeholder}">${content}</div>
+            </div>
+        `;
+    }
+
+    function buildDeploymentModalitiesCardHTML(selectedKeys = []) {
+        const selectedSet = new Set(selectedKeys);
+        const optionsHTML = DEPLOYMENT_MODALITIES.map(modality => {
+            const isSelected = selectedSet.has(modality.key);
+            return `
+            <div class="form-check modality-pill ${modality.accentClass} ${isSelected ? 'selected' : ''}">
+                <input class="form-check-input deployment-modality-toggle" type="checkbox" id="modality-${modality.key}" data-modality="${modality.key}" ${isSelected ? 'checked' : ''}>
+                <label class="form-check-label" for="modality-${modality.key}">
+                    <span class="modality-pill-icon"><i class="fas ${modality.icon}"></i></span>
+                    <span class="modality-pill-label">${modality.label}</span>
+                </label>
+            </div>
+        `;
+        }).join('');
+
+        return `
+            <div class="card section-card deployment-modalities-card">
+                <div class="section-header">
+                    <h5>Supported deployment modalities</h5>
+                    <p class="text-muted small mb-0">Select the deployment profiles your SCT can support.</p>
+                </div>
+                <div class="card-body">
+                    <div class="deployment-modality-grid">
+                        ${optionsHTML}
+                    </div>
+                </div>
+            </div>
+        `;
+    }
 
     function renderMakerUI() {
         const sectionsContainer = document.getElementById('sections-accordion');
         const weightsContainer = document.getElementById('weights-container');
         sectionsContainer.innerHTML = ''; weightsContainer.innerHTML = '';
+        renderDeploymentModalitiesSelector();
 
         Object.entries(TOOL_CONFIG).forEach(([key, config]) => {
+            if (config.editableContent && !SECTION_CONTENT[key]) {
+                const template = document.getElementById(`template-${key}`);
+                SECTION_CONTENT[key] = template ? template.innerHTML.trim() : '';
+            }
+
+            let sectionBody = '';
+            if (config.hasSubsections) {
+                sectionBody = `<h5>Estándares / Subsecciones (HTML y formato permitido)</h5><div id="subsections-${key}">${
+                    (config.subsections || []).map(sub => `
+                        <div class="subsection-item">
+                            ${getEditorTemplate(sub)}
+                            <button class="btn btn-danger btn-sm remove-item"><i class="fas fa-trash"></i></button>
+                        </div>`).join('')
+                }</div>
+                <button class="btn btn-outline-success mt-2 add-item" data-section="${key}"><i class="fas fa-plus me-2"></i>Añadir Estándar</button>`;
+            } else if (config.editableContent) {
+                sectionBody = `<h5>Contenido de la pestaña (HTML y formato permitido)</h5>
+                <div class="section-content-editor" data-section="${key}">
+                    ${getEditorTemplate(SECTION_CONTENT[key] || '', 'Edita el contenido de esta pestaña...')}
+                </div>`;
+            } else {
+                sectionBody = `<div class="alert alert-light">El contenido de esta sección es fijo y se insertará automáticamente en la herramienta final.</div>`;
+            }
+
             const sectionHTML = `
                 <div class="accordion-item" id="accordion-item-${key}">
                     <h2 class="accordion-header">
@@ -99,17 +291,7 @@
                                 <label class="form-label">Título de la Sección</label>
                                 <input type="text" class="form-control section-title-input" data-key="${key}" value="${config.title}">
                             </div>
-                            ${config.hasSubsections ?
-                                `<h5>Estándares / Subsecciones (HTML permitido)</h5><div id="subsections-${key}">${
-                                    config.subsections.map(sub => `
-                                        <div class="subsection-item">
-                                            <textarea class="form-control" rows="2">${sub.replace(/</g, '&lt;').replace(/>/g, '&gt;')}</textarea>
-                                            <button class="btn btn-danger btn-sm remove-item"><i class="fas fa-trash"></i></button>
-                                        </div>`).join('')
-                                }</div>
-                                <button class="btn btn-outline-success mt-2 add-item" data-section="${key}"><i class="fas fa-plus me-2"></i>Añadir Estándar</button>`
-                                : `<div class="alert alert-light">El contenido de esta sección es fijo y se insertará automáticamente en la herramienta final.</div>`
-                            }
+                            ${sectionBody}
                         </div>
                     </div>
                 </div>`;
@@ -122,6 +304,18 @@
         });
         updateWeightSum();
         addEventListeners();
+        setupRichTextEditors();
+
+        const firstItem = sectionsContainer.querySelector('.accordion-item');
+        if (firstItem) {
+            const firstButton = firstItem.querySelector('.accordion-button');
+            const firstCollapse = firstItem.querySelector('.accordion-collapse');
+            if (firstButton && firstCollapse) {
+                firstButton.classList.remove('collapsed');
+                firstButton.setAttribute('aria-expanded', 'true');
+                firstCollapse.classList.add('show');
+            }
+        }
     }
     
     function addEventListeners() {
@@ -130,11 +324,30 @@
             const container = document.getElementById(`subsections-${section}`);
             const newItem = document.createElement('div');
             newItem.className = 'subsection-item';
-            newItem.innerHTML = `<textarea class="form-control" rows="2" placeholder="Nuevo estándar..."></textarea><button class="btn btn-danger btn-sm remove-item"><i class="fas fa-trash"></i></button>`;
+            newItem.innerHTML = `${getEditorTemplate('')}<button class="btn btn-danger btn-sm remove-item"><i class="fas fa-trash"></i></button>`;
             container.appendChild(newItem);
-            newItem.querySelector('.remove-item').onclick = () => newItem.remove();
+            setupRichTextEditors(newItem);
+            const removeBtn = newItem.querySelector('.remove-item');
+            if (removeBtn) {
+                removeBtn.onclick = () => {
+                    if (activeEditor && newItem.contains(activeEditor)) {
+                        activeEditor = null;
+                        savedRange = null;
+                    }
+                    newItem.remove();
+                };
+            }
         });
-        document.querySelectorAll('.remove-item').forEach(btn => btn.onclick = e => e.currentTarget.closest('.subsection-item').remove());
+        document.querySelectorAll('.remove-item').forEach(btn => btn.onclick = e => {
+            const item = e.currentTarget.closest('.subsection-item');
+            if (item) {
+                if (activeEditor && item.contains(activeEditor)) {
+                    activeEditor = null;
+                    savedRange = null;
+                }
+                item.remove();
+            }
+        });
         document.querySelectorAll('.weight-input').forEach(input => input.oninput = updateWeightSum);
         document.querySelectorAll('.section-enable-switch').forEach(toggle => toggle.onchange = e => {
             const key = e.currentTarget.dataset.key;
@@ -144,6 +357,51 @@
             updateWeightSum();
         });
         document.getElementById('btn-make').onclick = generateHTML;
+    }
+
+    function setupRichTextEditors(root = document) {
+        root.querySelectorAll('.editor-content').forEach(editor => {
+            const updatePlaceholderState = () => {
+                const text = editor.innerText.trim();
+                editor.classList.toggle('empty', text.length === 0);
+            };
+            updatePlaceholderState();
+            editor.addEventListener('input', updatePlaceholderState);
+            editor.addEventListener('focus', () => {
+                activeEditor = editor;
+                editor.classList.add('focus');
+                storeSelection(editor);
+            });
+            editor.addEventListener('blur', () => {
+                editor.classList.remove('focus');
+                if (activeEditor === editor) {
+                    activeEditor = null;
+                    savedRange = null;
+                }
+            });
+            editor.addEventListener('keyup', () => storeSelection(editor));
+            editor.addEventListener('mouseup', () => storeSelection(editor));
+            editor.addEventListener('input', () => storeSelection(editor));
+            editor._updatePlaceholder = updatePlaceholderState;
+        });
+        root.querySelectorAll('.format-btn').forEach(btn => {
+            btn.onmousedown = e => {
+                e.preventDefault();
+                const command = btn.dataset.command;
+                const value = btn.dataset.value || null;
+                const container = btn.closest('.subsection-item') || btn.closest('.section-content-editor') || btn.closest('.rich-text-editor');
+                const editor = container ? container.querySelector('.editor-content') : null;
+                if (editor) {
+                    if (activeEditor !== editor) {
+                        activeEditor = editor;
+                    }
+                    restoreSelection(editor);
+                    document.execCommand(command, false, value);
+                    editor._updatePlaceholder?.();
+                    storeSelection(editor);
+                }
+            };
+        });
     }
 
     function updateWeightSum() {
@@ -166,8 +424,23 @@
                 weight: parseInt(document.querySelector(`.weight-input[data-key="${key}"]`)?.value || 0)
             };
             if (finalConfig[key].hasSubsections) {
-                finalConfig[key].subsections = Array.from(document.querySelectorAll(`#subsections-${key} textarea`)).map(area => area.value);
+                finalConfig[key].subsections = Array.from(document.querySelectorAll(`#subsections-${key} .editor-content`))
+                    .map(editor => editor.innerHTML.trim())
+                    .filter(content => content.length > 0);
             }
+            if (finalConfig[key].editableContent) {
+                const editor = document.querySelector(`#accordion-item-${key} .section-content-editor .editor-content`);
+                finalConfig[key].content = editor ? editor.innerHTML.trim() : '';
+            }
+        });
+
+        const selectedModalities = Array.from(document.querySelectorAll('.deployment-modality-checkbox'))
+            .filter(cb => cb.checked)
+            .map(cb => cb.dataset.key);
+        const deploymentModalitiesCardHTML = buildDeploymentModalitiesCardHTML(selectedModalities);
+        const defaultModalityState = {};
+        DEPLOYMENT_MODALITIES.forEach(modality => {
+            defaultModalityState[modality.key] = selectedModalities.includes(modality.key);
         });
 
         const enabledSections = Object.entries(finalConfig).filter(([, config]) => config.enabled);
@@ -176,14 +449,105 @@
         let sidebarLinks = enabledSections.map(([key, config]) => `
             <li class="nav-item"><a class="nav-link" href="#${key}" data-bs-toggle="tab"><i class="fas ${config.icon}"></i> ${config.title}</a></li>`).join('');
 
+        const escapeHTML = (value = '') => value
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;')
+            .replace(/'/g, '&#39;');
+
+        const stripHTML = (value = '') => value.replace(/<[^>]*>/g, ' ').replace(/\s+/g, ' ').trim();
+
         let tabPanes = enabledSections.map(([key, config]) => {
             let content = '';
             if (config.hasSubsections) {
-                const tableRows = config.subsections.map(sub => {
-                    const subId = sub.replace(/<[^>]*>?/gm, '').toLowerCase().replace(/[^a-z0-9]+/g, '-').slice(0, 50);
-                    return `<tr><td>${sub}</td><td><select class="form-select score-select" data-section="${key}" data-item="${subId}"><option value="">-</option><option value="0">0 - Not started</option><option value="1">1 - Initial</option><option value="2">2 - In progress</option><option value="3">3 - Completed</option><option value="NA">N/A</option></select></td><td><textarea class="form-control evidence-input" rows="2"></textarea></td><td><textarea class="form-control gaps-input" rows="2"></textarea></td><td><textarea class="form-control action-input" rows="2"></textarea></td></tr>`;
+                const subsectionCards = (config.subsections || []).map((sub, index) => {
+                    const separators = [': ', ':', ' – ', ' - ', ' — '];
+                    let separator = '';
+                    let separatorIndex = -1;
+                    for (const sep of separators) {
+                        const idx = sub.indexOf(sep);
+                        if (idx > -1) {
+                            separator = sep;
+                            separatorIndex = idx;
+                            break;
+                        }
+                    }
+                    let titleHTML = sub;
+                    let bodyHTML = sub;
+                    if (separatorIndex > -1) {
+                        titleHTML = sub.slice(0, separatorIndex);
+                        bodyHTML = sub.slice(separatorIndex + separator.length).trim() || sub;
+                    }
+                    const titleText = stripHTML(titleHTML) || `Standard ${index + 1}`;
+                    const baseId = stripHTML(`${titleText}-${index + 1}`).toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
+                    const subId = `${index + 1}-${baseId || 'item'}`.slice(0, 60);
+                    const safeTitle = escapeHTML(titleText);
+                    return `
+                        <div class="compliance-card" data-section="${key}" data-item="${subId}">
+                            <div class="card-inner">
+                                <div class="card-header">
+                                    <h5 class="subsection-title">${safeTitle}</h5>
+                                </div>
+                                <div class="card-body">
+                                    <div class="card-description">${bodyHTML}</div>
+                                    <div class="card-fields">
+                                        <div class="field-group">
+                                            <label>Describe evidence</label>
+                                            <textarea class="form-control evidence-input" data-section="${key}" data-item="${subId}" rows="3"></textarea>
+                                        </div>
+                                        <div class="field-group">
+                                            <label>Gaps</label>
+                                            <textarea class="form-control gaps-input" data-section="${key}" data-item="${subId}" rows="3"></textarea>
+                                        </div>
+                                        <div class="field-group">
+                                            <label>Actions</label>
+                                            <textarea class="form-control action-input" data-section="${key}" data-item="${subId}" rows="3"></textarea>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="card-footer">
+                                    <div class="score-select-wrapper">
+                                        <label>Compliance score</label>
+                                        <select class="form-select score-select compliance-score" data-section="${key}" data-item="${subId}">
+                                            <option value="">-</option>
+                                            <option value="0" selected>0 - Not started</option>
+                                            <option value="1">1 - Initial</option>
+                                            <option value="2">2 - In progress</option>
+                                            <option value="3">3 - Completed</option>
+                                            <option value="NA">N/A</option>
+                                        </select>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>`;
                 }).join('');
-                content = `<h2 class="mb-4">${config.title}</h2><div class="card section-card"><div class="section-header d-flex justify-content-between align-items-center"><h5>${config.title} Compliance</h5><div class="score-display" id="${key}Score">0% Complete</div></div><table class="assessment-table"><thead><tr><th width="40%">Standard</th><th width="10%">Score</th><th width="20%">Evidence</th><th width="15%">Gaps</th><th width="15%">Actions</th></tr></thead><tbody>${tableRows}</tbody></table><div class="comments-section"><label for="${key}Comments" class="form-label">Mentor Comments & Observations</label><textarea class="form-control" id="${key}Comments" rows="3"></textarea></div></div>`;
+
+                content = `
+                    <section class="compliance-section">
+                        <div class="section-banner">
+                            <div class="banner-info">
+                                <h2>${config.title}</h2>
+                                <p>Compliance</p>
+                            </div>
+                            <div class="section-progress">
+                                <span class="progress-pill" id="${key}Score">0% Complete</span>
+                            </div>
+                        </div>
+                        <div class="subsection-list">
+                            ${subsectionCards}
+                        </div>
+                        <div class="comments-panel">
+                            <label for="${key}Comments" class="form-label">Mentor Comments &amp; Observations</label>
+                            <textarea class="form-control" id="${key}Comments" rows="4"></textarea>
+                        </div>
+                    </section>`;
+            } else if (config.editableContent) {
+                let tabContent = config.content || '';
+                if (key === 'org-detail') {
+                    tabContent += deploymentModalitiesCardHTML;
+                }
+                content = tabContent;
             } else {
                 content = document.getElementById(`template-${key}`).innerHTML;
             }
@@ -197,6 +561,9 @@
             .filter(([,c]) => c.weight > 0)
             .map(([k,c]) => ({ name: c.title.toUpperCase(), weight: c.weight, section: k }));
 
+        const modalityMetadataJSON = JSON.stringify(DEPLOYMENT_MODALITIES);
+        const defaultModalityStateJSON = JSON.stringify(defaultModalityState);
+
         const fullHTML = `
 <!DOCTYPE html>
 <html lang="es">
@@ -206,7 +573,474 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     <script src="https://cdn.jsdelivr.net/npm/xlsx@0.18.5/dist/xlsx.full.min.js"><\/script>
-    <style>:root{--primary:#0d6efd;--secondary:#6c757d;--success:#198754;--info:#0dcaf0;--warning:#ffc107;--danger:#dc3545;--light:#f8f9fa;--dark:#212529}body{font-family:'Segoe UI',Tahoma,Geneva,Verdana,sans-serif;background-color:#f5f7f9;padding:20px 0}.app-container{max-width:1400px;margin:0 auto;background:white;box-shadow:0 0 15px rgba(0,0,0,.1);border-radius:8px;overflow:hidden}.sidebar{background-color:#2c3e50;color:white;height:100vh;position:sticky;top:0;padding-top:20px;overflow-y:auto}.sidebar .nav-link{color:rgba(255,255,255,.8);border-left:3px solid transparent;padding:10px 15px;margin:5px 0;transition:all .3s}.sidebar .nav-link:hover,.sidebar .nav-link.active{color:white;background-color:rgba(255,255,255,.1);border-left-color:var(--info)}.sidebar .nav-link i{margin-right:10px;width:20px;text-align:center}.main-content{padding:20px;max-height:100vh;overflow-y:auto}.progress-sidebar{background-color:#f8f9fa;height:100vh;position:sticky;top:0;padding:20px 15px;overflow-y:auto;border-left:1px solid #e9ecef}.progress-bar-container{background-color:#e9ecef;border-radius:5px;margin-bottom:20px;height:30px}.progress-bar{height:100%;border-radius:5px;transition:width .5s ease}.section-card{margin-bottom:20px;box-shadow:0 4px 6px rgba(0,0,0,.1);border:none;border-radius:8px}.section-header{background-color:#f8f9fa;padding:15px;border-bottom:1px solid #e9ecef;border-radius:8px 8px 0 0}.comments-section{background-color:#f8f9fa;padding:15px;border-radius:0 0 8px 8px;border-top:1px solid #e9ecef}.overview-card{text-align:center;padding:20px;border-radius:8px;margin-bottom:20px;box-shadow:0 4px 6px rgba(0,0,0,.1)}.overview-card .card-value{font-size:2rem;font-weight:bold;margin:10px 0}.score-display{font-size:1.2rem;font-weight:bold;color:var(--primary)}.assessment-table{width:100%;border-collapse:collapse;margin-bottom:20px}.assessment-table th,.assessment-table td{border:1px solid #dee2e6;padding:12px;text-align:left;vertical-align:middle}.assessment-table th{background-color:#f8f9fa;font-weight:600}.score-0{background:#fee2e2;color:#dc2626}.score-1{background:#fed7aa;color:#ea580c}.score-2{background:#fef3c7;color:#ca8a04}.score-3{background:#d1fae5;color:#059669}.notification{position:fixed;top:20px;right:20px;background:linear-gradient(135deg,#4ade80 0%,#22c55e 100%);color:white;padding:15px 25px;border-radius:8px;box-shadow:0 5px 20px rgba(0,0,0,.2);z-index:1000;animation:slideIn .3s ease}.progress-sidebar-table{width:100%;font-size:.85rem}.progress-sidebar-table th,.progress-sidebar-table td{padding:8px 5px;border-bottom:1px solid #dee2e6}.progress-sidebar-table th{font-weight:600}.progress-sidebar-table tr:last-child td{border-bottom:none}@keyframes slideIn{from{transform:translateX(100%);opacity:0}to{transform:translateX(0);opacity:1}}@keyframes fadeOut{from{opacity:1}to{opacity:0}}.summary-textarea{min-height:100px;resize:vertical}.file-input{display:none}@media (max-width:992px){.progress-sidebar{display:none}.main-content{max-height:none}}@media (max-width:768px){.sidebar{height:auto;position:relative}.assessment-table{font-size:.9rem;display:block;overflow-x:auto}.assessment-table th,.assessment-table td{padding:8px;white-space:nowrap}}<\/style>
+    <style>
+        :root {
+            --primary: #0d6efd;
+            --secondary: #6c757d;
+            --success: #198754;
+            --info: #0dcaf0;
+            --warning: #ffc107;
+            --danger: #dc3545;
+            --light: #f8f9fa;
+            --dark: #212529;
+        }
+
+        body {
+            font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+            background-color: #f5f7f9;
+            padding: 20px 0;
+        }
+
+        .app-container {
+            max-width: 1400px;
+            margin: 0 auto;
+            background: white;
+            box-shadow: 0 0 20px rgba(15, 23, 42, 0.12);
+            border-radius: 16px;
+            overflow: hidden;
+        }
+
+        .sidebar {
+            background: linear-gradient(180deg, #1f2937 0%, #111827 100%);
+            color: white;
+            height: 100vh;
+            position: sticky;
+            top: 0;
+            padding-top: 20px;
+            overflow-y: auto;
+        }
+
+        .sidebar .nav-link {
+            color: rgba(255, 255, 255, 0.8);
+            border-left: 3px solid transparent;
+            padding: 10px 15px;
+            margin: 5px 0;
+            transition: all 0.3s ease;
+        }
+
+        .sidebar .nav-link:hover,
+        .sidebar .nav-link.active {
+            color: white;
+            background-color: rgba(255, 255, 255, 0.1);
+            border-left-color: #a855f7;
+        }
+
+        .sidebar .nav-link i {
+            margin-right: 10px;
+            width: 20px;
+            text-align: center;
+        }
+
+        .main-content {
+            padding: 24px;
+            max-height: 100vh;
+            overflow-y: auto;
+            background: #f8f9ff;
+        }
+
+        .progress-sidebar {
+            background-color: #ffffff;
+            height: 100vh;
+            position: sticky;
+            top: 0;
+            padding: 24px 18px;
+            overflow-y: auto;
+            border-left: 1px solid #e5e7eb;
+        }
+
+        .progress-bar-container {
+            background-color: #eef2ff;
+            border-radius: 999px;
+            margin-bottom: 20px;
+            height: 16px;
+            overflow: hidden;
+        }
+
+        .progress-bar {
+            height: 100%;
+            border-radius: 999px;
+            transition: width 0.5s ease;
+        }
+
+        .section-card {
+            margin-bottom: 20px;
+            box-shadow: 0 4px 12px rgba(15, 23, 42, 0.08);
+            border: none;
+            border-radius: 12px;
+        }
+
+        .deployment-modalities-card .section-header {
+            display: flex;
+            flex-direction: column;
+            gap: 4px;
+            background: #f8f9ff;
+            padding: 18px 20px;
+            border-bottom: 1px solid #e2e8f0;
+        }
+
+        .deployment-modalities-card .card-body {
+            padding: 20px;
+        }
+
+        .deployment-modality-grid {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 16px;
+        }
+
+        .modality-pill {
+            display: flex;
+            align-items: center;
+            gap: 12px;
+            padding: 12px 20px;
+            border-radius: 999px;
+            background: #f8fafc;
+            border: 1px solid #cbd5f5;
+            transition: all 0.2s ease;
+        }
+
+        .modality-pill.selected {
+            background: linear-gradient(135deg, rgba(79, 70, 229, 0.12), rgba(59, 130, 246, 0.12));
+            border-color: transparent;
+            box-shadow: 0 10px 24px rgba(59, 130, 246, 0.18);
+        }
+
+        .modality-pill .form-check-label {
+            display: flex;
+            align-items: center;
+            gap: 12px;
+            margin-bottom: 0;
+            cursor: pointer;
+            font-weight: 600;
+            color: #334155;
+        }
+
+        .modality-pill input {
+            display: none;
+        }
+
+        .modality-pill-icon {
+            width: 34px;
+            height: 34px;
+            border-radius: 50%;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            color: #ffffff;
+            font-size: 1rem;
+        }
+
+        .modality-pill.embedded .modality-pill-icon {
+            background: linear-gradient(135deg, #2563eb, #3b82f6);
+        }
+
+        .modality-pill.coupled .modality-pill-icon {
+            background: linear-gradient(135deg, #f59e0b, #fbbf24);
+        }
+
+        .modality-pill.self-sustained .modality-pill-icon {
+            background: linear-gradient(135deg, #16a34a, #22c55e);
+        }
+
+        .section-header {
+            background-color: #f8f9ff;
+            padding: 15px;
+            border-bottom: 1px solid #e5e7eb;
+            border-radius: 12px 12px 0 0;
+        }
+
+        .overview-card {
+            text-align: center;
+            padding: 20px;
+            border-radius: 14px;
+            margin-bottom: 20px;
+            box-shadow: 0 10px 24px rgba(15, 23, 42, 0.12);
+        }
+
+        .overview-card .card-value {
+            font-size: 2rem;
+            font-weight: 700;
+            margin: 10px 0;
+        }
+
+        .notification {
+            position: fixed;
+            top: 20px;
+            right: 20px;
+            background: linear-gradient(135deg, #4ade80 0%, #22c55e 100%);
+            color: white;
+            padding: 15px 25px;
+            border-radius: 12px;
+            box-shadow: 0 12px 30px rgba(34, 197, 94, 0.3);
+            z-index: 1000;
+            animation: slideIn 0.3s ease;
+        }
+
+        .progress-sidebar-table {
+            width: 100%;
+            font-size: 0.85rem;
+        }
+
+        .progress-sidebar-table th,
+        .progress-sidebar-table td {
+            padding: 8px 5px;
+            border-bottom: 1px solid #e5e7eb;
+        }
+
+        .progress-sidebar-table th {
+            font-weight: 600;
+        }
+
+        .progress-sidebar-table tr:last-child td {
+            border-bottom: none;
+        }
+
+        .compliance-section {
+            margin-bottom: 32px;
+        }
+
+        .section-banner {
+            background: linear-gradient(135deg, #6d5dfc 0%, #8f75ff 100%);
+            color: white;
+            padding: 24px;
+            border-radius: 20px;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            gap: 1.5rem;
+            box-shadow: 0 16px 40px rgba(109, 93, 252, 0.3);
+        }
+
+        .section-progress {
+            display: flex;
+            align-items: center;
+            gap: 0.75rem;
+        }
+
+        .section-banner h2 {
+            margin: 0;
+            font-weight: 700;
+            letter-spacing: 0.02em;
+        }
+
+        .section-banner p {
+            margin: 0;
+            opacity: 0.85;
+            font-size: 1rem;
+            letter-spacing: 0.03em;
+        }
+
+        .progress-pill {
+            background: rgba(255, 255, 255, 0.22);
+            padding: 0.6rem 1.75rem;
+            border-radius: 999px;
+            font-weight: 600;
+            letter-spacing: 0.05em;
+            text-transform: uppercase;
+        }
+
+        .subsection-list {
+            display: grid;
+            gap: 1.5rem;
+            margin-top: 1.75rem;
+        }
+
+        .compliance-card {
+            background: #ffffff;
+            border-radius: 18px;
+            border: 1px solid #e4e9ff;
+            box-shadow: 0 12px 32px rgba(79, 70, 229, 0.12);
+            overflow: hidden;
+            transition: transform 0.2s ease, box-shadow 0.2s ease;
+        }
+
+        .compliance-card:hover {
+            transform: translateY(-2px);
+            box-shadow: 0 18px 40px rgba(79, 70, 229, 0.18);
+        }
+
+        .compliance-card .card-header {
+            background: linear-gradient(90deg, #eef2ff 0%, #f7f9ff 100%);
+            padding: 1.1rem 1.5rem;
+            border-bottom: 1px solid #dbe4ff;
+        }
+
+        .subsection-title {
+            margin: 0;
+            font-size: 1.1rem;
+            font-weight: 600;
+            color: #4338ca;
+        }
+
+        .compliance-card .card-body {
+            padding: 1.5rem;
+            display: flex;
+            flex-direction: column;
+            gap: 1.25rem;
+        }
+
+        .card-description {
+            color: #334155;
+            line-height: 1.6;
+        }
+
+        .card-fields {
+            display: grid;
+            gap: 1rem;
+            grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+        }
+
+        .field-group label {
+            font-size: 0.78rem;
+            text-transform: uppercase;
+            letter-spacing: 0.08em;
+            color: #64748b;
+            margin-bottom: 0.35rem;
+            display: block;
+        }
+
+        .field-group textarea {
+            border-radius: 12px;
+            border: 1px solid #d7def8;
+            padding: 0.75rem;
+            min-height: 96px;
+            background-color: #f8faff;
+            transition: border-color 0.2s ease, box-shadow 0.2s ease;
+        }
+
+        .field-group textarea:focus {
+            border-color: #7c3aed;
+            box-shadow: 0 0 0 0.2rem rgba(124, 58, 237, 0.15);
+        }
+
+        .compliance-card .card-footer {
+            padding: 1rem 1.5rem;
+            background: #f8fafc;
+            border-top: 1px solid #e2e8f0;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 1rem;
+            justify-content: space-between;
+            align-items: center;
+        }
+
+        .score-select-wrapper label {
+            font-weight: 600;
+            color: #475569;
+            margin-bottom: 0.35rem;
+            display: block;
+        }
+
+        .compliance-score {
+            max-width: 220px;
+            border-radius: 999px;
+            border: 1px solid #cbd5f5;
+            padding: 0.55rem 1rem;
+            font-weight: 600;
+            color: #334155;
+            background-color: #ffffff;
+            transition: all 0.3s ease;
+        }
+
+        .compliance-score:focus {
+            border-color: #7c3aed;
+            box-shadow: 0 0 0 0.25rem rgba(124, 58, 237, 0.15);
+        }
+
+        .score-select.score-0 {
+            background: #fee2e2;
+            color: #991b1b;
+            border-color: #fecaca;
+        }
+
+        .score-select.score-1 {
+            background: #fef3c7;
+            color: #92400e;
+            border-color: #fde68a;
+        }
+
+        .score-select.score-2 {
+            background: #dcfce7;
+            color: #047857;
+            border-color: #bbf7d0;
+        }
+
+        .score-select.score-3 {
+            background: #dbeafe;
+            color: #1d4ed8;
+            border-color: #bfdbfe;
+        }
+
+        .comments-panel {
+            margin-top: 2rem;
+            background: #f8f9ff;
+            border: 1px solid #dde3ff;
+            border-radius: 18px;
+            padding: 1.25rem;
+        }
+
+        .comments-panel textarea {
+            min-height: 140px;
+            border-radius: 12px;
+            border: 1px solid #d7def8;
+            background-color: #ffffff;
+        }
+
+        .summary-textarea {
+            min-height: 100px;
+            resize: vertical;
+        }
+
+        .file-input {
+            display: none;
+        }
+
+        @keyframes slideIn {
+            from {
+                transform: translateX(100%);
+                opacity: 0;
+            }
+            to {
+                transform: translateX(0);
+                opacity: 1;
+            }
+        }
+
+        @keyframes fadeOut {
+            from {
+                opacity: 1;
+            }
+            to {
+                opacity: 0;
+            }
+        }
+
+        @media (max-width: 1200px) {
+            .progress-sidebar {
+                display: none;
+            }
+
+            .main-content {
+                max-height: none;
+            }
+        }
+
+        @media (max-width: 768px) {
+            .sidebar {
+                height: auto;
+                position: relative;
+            }
+
+            .section-banner {
+                flex-direction: column;
+                align-items: flex-start;
+            }
+
+            .compliance-score {
+                width: 100%;
+            }
+        }
+    <\/style>
 <\/head>
 <body>
     <div class="app-container"><div class="row g-0">
@@ -218,16 +1052,349 @@
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"><\/script>
     <script>
     const SECTIONS_WITH_WEIGHT = ${JSON.stringify(weightsData)};
+    const MODALITY_METADATA = ${modalityMetadataJSON};
+    const DEFAULT_MODALITY_STATE = ${defaultModalityStateJSON};
     let assessmentData={teamInfo:{},scores:{},evidence:{},gaps:{},actions:{},comments:{},summary:{}};
-    function initializeData(){const e=localStorage.getItem("hidSCTAssessment");e&&(assessmentData=JSON.parse(e),loadSavedData()),updateProgress()}
-    function loadSavedData(){if(assessmentData.teamInfo&&Object.keys(assessmentData.teamInfo).forEach(e=>{const t=document.getElementById(e);t&&(t.value=assessmentData.teamInfo[e])}),document.querySelectorAll(".score-select").forEach(e=>{const t=e.dataset.section+"-"+e.dataset.item;if(assessmentData.scores[t]){e.value=assessmentData.scores[t],updateScoreBadge(e);const s=e.closest("tr");s&&(s.querySelector(".evidence-input").value=assessmentData.evidence[t]||"",s.querySelector(".gaps-input").value=assessmentData.gaps[t]||"",s.querySelector(".action-input").value=assessmentData.actions[t]||"")}}),assessmentData.comments&&Object.keys(assessmentData.comments).forEach(e=>{const t=document.getElementById(e);t&&(t.value=assessmentData.comments[e])}),assessmentData.summary){const e=assessmentData.summary;Object.keys(e).forEach(t=>{const s=document.getElementById(t);s&&(s.value=e[t])})}}
-    function saveProgress(){assessmentData.teamInfo={teamName:document.getElementById("teamName")?.value,region:document.getElementById("region")?.value,country:document.getElementById("country")?.value,mentorName:document.getElementById("mentorName")?.value,hqName:document.getElementById("hqName")?.value,hqEmail:document.getElementById("hqEmail")?.value,hqPhone:document.getElementById("hqPhone")?.value,hqPosition:document.getElementById("hqPosition")?.value,opsName:document.getElementById("opsName")?.value,opsEmail:document.getElementById("opsEmail")?.value,opsPhone:document.getElementById("opsPhone")?.value,opsPosition:document.getElementById("opsPosition")?.value},assessmentData.scores={},assessmentData.evidence={},assessmentData.gaps={},assessmentData.actions={},document.querySelectorAll(".score-select").forEach(e=>{const t=e.dataset.section+"-"+e.dataset.item,s=e.closest("tr");e.value&&(assessmentData.scores[t]=e.value);const a=s.querySelector(".evidence-input"),o=s.querySelector(".gaps-input"),n=s.querySelector(".action-input");a&&(assessmentData.evidence[t]=a.value),o&&(assessmentData.gaps[t]=o.value),n&&(assessmentData.actions[t]=n.value)}),assessmentData.comments={},SECTIONS_WITH_WEIGHT.forEach(e=>{const t=document.getElementById(e.section+"Comments");t&&(assessmentData.comments[e.section+"Comments"]=t.value)}),assessmentData.summary={strengths:document.getElementById("strengths")?.value,criticalGaps:document.getElementById("criticalGaps")?.value,immediateActions:document.getElementById("immediateActions")?.value,shortTermActions:document.getElementById("shortTermActions")?.value,mediumTermActions:document.getElementById("mediumTermActions")?.value,technicalAssistance:document.getElementById("technicalAssistance")?.value,trainingRequirements:document.getElementById("trainingRequirements")?.value,resourceRequirements:document.getElementById("resourceRequirements")?.value,nextSteps:document.getElementById("nextSteps")?.value,completionDate:document.getElementById("completionDate")?.value,reviewedBy:document.getElementById("reviewedBy")?.value,mentorAssignment:document.getElementById("mentorAssignment")?.value},localStorage.setItem("hidSCTAssessment",JSON.stringify(assessmentData)),showNotification("Progress saved successfully!"),updateProgress()}
+    function initializeData(){
+        const stored = localStorage.getItem("hidSCTAssessment");
+        if (stored) {
+            try {
+                const parsed = JSON.parse(stored);
+                assessmentData = {
+                    teamInfo: parsed.teamInfo || {},
+                    scores: parsed.scores || {},
+                    evidence: parsed.evidence || {},
+                    gaps: parsed.gaps || {},
+                    actions: parsed.actions || {},
+                    comments: parsed.comments || {},
+                    summary: parsed.summary || {}
+                };
+            } catch (error) {
+                console.warn('Failed to parse saved assessment data', error);
+                assessmentData = {teamInfo:{},scores:{},evidence:{},gaps:{},actions:{},comments:{},summary:{}};
+            }
+        }
+
+        assessmentData.teamInfo = assessmentData.teamInfo || {};
+        if (!assessmentData.teamInfo.deploymentModalities) {
+            assessmentData.teamInfo.deploymentModalities = { ...DEFAULT_MODALITY_STATE };
+        }
+
+        loadSavedData();
+        updateProgress();
+    }
+    function loadSavedData(){
+        assessmentData.teamInfo = assessmentData.teamInfo || {};
+        const modalityState = { ...DEFAULT_MODALITY_STATE, ...(assessmentData.teamInfo.deploymentModalities || {}) };
+
+        MODALITY_METADATA.forEach(modality => {
+            const checkbox = document.getElementById('modality-' + modality.key);
+            if (checkbox) {
+                const isChecked = !!modalityState[modality.key];
+                checkbox.checked = isChecked;
+                const pill = checkbox.closest('.modality-pill');
+                if (pill) {
+                    pill.classList.toggle('selected', isChecked);
+                }
+            }
+        });
+
+        assessmentData.teamInfo.deploymentModalities = modalityState;
+
+        Object.keys(assessmentData.teamInfo).forEach(field => {
+            if (field === 'deploymentModalities') return;
+            const input = document.getElementById(field);
+            if (input) {
+                input.value = assessmentData.teamInfo[field];
+            }
+        });
+
+        document.querySelectorAll('.compliance-card').forEach(card => {
+            const select = card.querySelector('.score-select');
+            if (!select) return;
+            const key = select.dataset.section + '-' + select.dataset.item;
+            if (assessmentData.scores && assessmentData.scores[key] !== undefined && assessmentData.scores[key] !== null && assessmentData.scores[key] !== '') {
+                select.value = assessmentData.scores[key];
+            } else {
+                select.value = '0';
+            }
+            updateScoreBadge(select);
+            const evidenceField = card.querySelector('.evidence-input');
+            const gapsField = card.querySelector('.gaps-input');
+            const actionField = card.querySelector('.action-input');
+            if (evidenceField) {
+                evidenceField.value = (assessmentData.evidence && assessmentData.evidence[key]) || '';
+            }
+            if (gapsField) {
+                gapsField.value = (assessmentData.gaps && assessmentData.gaps[key]) || '';
+            }
+            if (actionField) {
+                actionField.value = (assessmentData.actions && assessmentData.actions[key]) || '';
+            }
+        });
+
+        if (assessmentData.comments) {
+            Object.keys(assessmentData.comments).forEach(id => {
+                const field = document.getElementById(id);
+                if (field) {
+                    field.value = assessmentData.comments[id];
+                }
+            });
+        }
+
+        if (assessmentData.summary) {
+            Object.keys(assessmentData.summary).forEach(id => {
+                const field = document.getElementById(id);
+                if (field) {
+                    field.value = assessmentData.summary[id];
+                }
+            });
+        }
+    }
+    function saveProgress(){
+        const modalityState = { ...DEFAULT_MODALITY_STATE };
+        MODALITY_METADATA.forEach(modality => {
+            const checkbox = document.getElementById('modality-' + modality.key);
+            if (checkbox) {
+                modalityState[modality.key] = checkbox.checked;
+                const pill = checkbox.closest('.modality-pill');
+                if (pill) {
+                    pill.classList.toggle('selected', checkbox.checked);
+                }
+            }
+        });
+
+        assessmentData.teamInfo = {
+            teamName: document.getElementById('teamName')?.value,
+            region: document.getElementById('region')?.value,
+            country: document.getElementById('country')?.value,
+            mentorName: document.getElementById('mentorName')?.value,
+            hqName: document.getElementById('hqName')?.value,
+            hqEmail: document.getElementById('hqEmail')?.value,
+            hqPhone: document.getElementById('hqPhone')?.value,
+            hqPosition: document.getElementById('hqPosition')?.value,
+            opsName: document.getElementById('opsName')?.value,
+            opsEmail: document.getElementById('opsEmail')?.value,
+            opsPhone: document.getElementById('opsPhone')?.value,
+            opsPosition: document.getElementById('opsPosition')?.value,
+            deploymentModalities: modalityState
+        };
+
+        assessmentData.scores = {};
+        assessmentData.evidence = {};
+        assessmentData.gaps = {};
+        assessmentData.actions = {};
+
+        document.querySelectorAll('.compliance-card').forEach(card => {
+            const select = card.querySelector('.score-select');
+            if (!select) return;
+            const key = select.dataset.section + '-' + select.dataset.item;
+            if (select.value) {
+                assessmentData.scores[key] = select.value;
+            }
+            const evidenceField = card.querySelector('.evidence-input');
+            const gapsField = card.querySelector('.gaps-input');
+            const actionField = card.querySelector('.action-input');
+            if (evidenceField) assessmentData.evidence[key] = evidenceField.value || '';
+            if (gapsField) assessmentData.gaps[key] = gapsField.value || '';
+            if (actionField) assessmentData.actions[key] = actionField.value || '';
+        });
+
+        assessmentData.comments = {};
+        SECTIONS_WITH_WEIGHT.forEach(section => {
+            const commentField = document.getElementById(section.section + 'Comments');
+            if (commentField) {
+                assessmentData.comments[section.section + 'Comments'] = commentField.value || '';
+            }
+        });
+
+        assessmentData.summary = {
+            strengths: document.getElementById('strengths')?.value,
+            criticalGaps: document.getElementById('criticalGaps')?.value,
+            immediateActions: document.getElementById('immediateActions')?.value,
+            shortTermActions: document.getElementById('shortTermActions')?.value,
+            mediumTermActions: document.getElementById('mediumTermActions')?.value,
+            technicalAssistance: document.getElementById('technicalAssistance')?.value,
+            trainingRequirements: document.getElementById('trainingRequirements')?.value,
+            resourceRequirements: document.getElementById('resourceRequirements')?.value,
+            nextSteps: document.getElementById('nextSteps')?.value,
+            completionDate: document.getElementById('completionDate')?.value,
+            reviewedBy: document.getElementById('reviewedBy')?.value,
+            mentorAssignment: document.getElementById('mentorAssignment')?.value
+        };
+
+        localStorage.setItem('hidSCTAssessment', JSON.stringify(assessmentData));
+        showNotification('Progress saved successfully!');
+        updateProgress();
+    }
     function showNotification(e){const t=document.createElement("div");t.className="notification",t.textContent=e,document.body.appendChild(t),setTimeout(()=>{t.style.animation="fadeOut .3s ease",setTimeout(()=>t.remove(),300)},3e3)}
-    function updateScoreBadge(e){const t=e.value;e.className="form-select score-select",""!==t&&"NA"!==t&&e.classList.add("score-"+t)}
+    function updateScoreBadge(select){
+        const value = select.value;
+        select.className = 'form-select score-select compliance-score';
+        if (value !== '' && value !== 'NA') {
+            select.classList.add('score-' + value);
+        }
+    }
     function updateProgress(){let e=0,t=0,s=0;const a={};SECTIONS_WITH_WEIGHT.forEach(e=>{a[e.section]={score:0,maxScore:0}});let o=0,n=0;document.querySelectorAll(".score-select").forEach(e=>{const t=e.dataset.section;a[t]&&(o++,""!==e.value&&(n++,"NA"!==e.value&&(a[t].score+=parseInt(e.value),a[t].maxScore+=3)))});let i=0;SECTIONS_WITH_WEIGHT.forEach(s=>{const o=a[s.section];let n=0;o.maxScore>0&&(n=Math.round(o.score/o.maxScore*100));const c=document.getElementById(s.section+"Score");c&&(c.textContent=n+"% Complete"),e+=s.weight,t+=s.weight*n/100}),i=e>0?Math.round(t/e*100):0,s=Object.values(a).filter(e=>e.maxScore>0).length,document.getElementById("overallProgressBar").style.width=i+"%",document.getElementById("overallProgressText").textContent=i+"%",document.getElementById("sidebarProgressBar").style.width=i+"%",document.getElementById("sidebarProgressText").textContent=i+"%",document.getElementById("completedSections").textContent=s+"/"+SECTIONS_WITH_WEIGHT.length,document.getElementById("overallScore").textContent=i+"%",document.getElementById("lastUpdated").textContent=(new Date).toLocaleDateString();const c=document.getElementById("progressTableBody"),d=document.getElementById("progressSidebarBody");c.innerHTML="",d.innerHTML="";let r=0,l=0;SECTIONS_WITH_WEIGHT.forEach(e=>{const t=a[e.section];let s=0;t.maxScore>0&&(s=Math.round(t.score/t.maxScore*100));const o=0===s?"Not Started":s<100?"In Progress":"Completed",n="Completed"===o?"bg-success":"In Progress"===o?"bg-warning":"bg-secondary";r+=e.weight,l+=e.weight*s/100,c.innerHTML+=\`<tr><td>\${e.name}</td><td>\${e.weight}%</td><td><span class="badge \${n}">\${o}</span></td><td>\${s}%</td></tr>\`,d.innerHTML+=\`<tr><td>\${e.name.split(" ")[0]}</td><td><span class="badge \${n}">\${o}</span></td><td>\${s}%</td></tr>\`});const m=r>0?Math.round(l/r*100):0;c.innerHTML+=\`<tr class="table-primary fw-bold"><td>TOTAL</td><td>\${r}%</td><td></td><td>\${m}%</td></tr>\`}
-    function exportToExcel(){saveProgress();const e=XLSX.utils.book_new(),t=[["Team Information",""],["Team Name",assessmentData.teamInfo.teamName||""],["Region",assessmentData.teamInfo.region||""],["Country",assessmentData.teamInfo.country||""],["Mentor Name",assessmentData.teamInfo.mentorName||""],[""],["Headquarters Contact",""],["Name",assessmentData.teamInfo.hqName||""],["Email",assessmentData.teamInfo.hqEmail||""],["Phone",assessmentData.teamInfo.hqPhone||""],["Position",assessmentData.teamInfo.hqPosition||""],[""],["Operations Contact",""],["Name",assessmentData.teamInfo.opsName||""],["Email",assessmentData.teamInfo.opsEmail||""],["Phone",assessmentData.teamInfo.opsPhone||""],["Position",assessmentData.teamInfo.opsPosition||""]],s=XLSX.utils.aoa_to_sheet(t);XLSX.utils.book_append_sheet(e,s,"Team Info");const a=[["Standard ID","Pillar","Standard Statement","Score","Evidence","Gaps","Actions","Comments"]];document.querySelectorAll(".score-select").forEach(e=>{const t=e.closest("tr"),s=t.cells[0].innerHTML,o=e.dataset.section,n=e.dataset.section+"-"+e.dataset.item;a.push([n,o,s,e.value||"",t.querySelector(".evidence-input")?.value||"",t.querySelector(".gaps-input")?.value||"",t.querySelector(".action-input")?.value||"",assessmentData.comments[o+"Comments"]||""])});const o=XLSX.utils.aoa_to_sheet(a);XLSX.utils.book_append_sheet(e,o,"HID SCT Assessment"),XLSX.writeFile(e,"HID_SCT_Assessment_"+(new Date).toISOString().split("T")[0]+".xlsx"),showNotification("Data exported to Excel successfully!")}
-    function importFromExcel(e){const t=e.target.files[0];if(!t)return;const s=new FileReader;s.onload=function(e){try{const t=(new Uint8Array(e.target.result),XLSX.read(e.target.result,{type:"binary"}));assessmentData={teamInfo:{},scores:{},evidence:{},gaps:{},actions:{},comments:{},summary:{}};const s=t.Sheets["HID SCT Assessment"],a=XLSX.utils.sheet_to_json(s);for(const e of a)assessmentData.scores[e["Standard ID"]]=e.Score,assessmentData.evidence[e["Standard ID"]]=e.Evidence,assessmentData.gaps[e["Standard ID"]]=e.Gaps,assessmentData.actions[e["Standard ID"]]=e.Actions;localStorage.setItem("hidSCTAssessment",JSON.stringify(assessmentData)),loadSavedData(),updateProgress(),showNotification("Data imported successfully!")}catch(e){showNotification("Error importing file.")}},s.readAsBinaryString(t)}
-    document.addEventListener("DOMContentLoaded",function(){initializeData(),document.querySelectorAll("input, textarea, select").forEach(e=>{e.addEventListener("change",saveProgress)}),document.getElementById("btn-save").addEventListener("click",saveProgress),document.getElementById("btn-export-json").addEventListener("click",()=>{saveProgress();const e=JSON.stringify(assessmentData,null,2),t=new Blob([e],{type:"application/json"}),s=URL.createObjectURL(t),a=document.createElement("a");a.href=s,a.download="HID_SCT_Assessment_"+(new Date).toISOString().split("T")[0]+".json",a.click(),URL.revokeObjectURL(s)}),document.getElementById("btn-export-excel").addEventListener("click",exportToExcel),document.getElementById("btn-submit").addEventListener("click",()=>{saveProgress(),showNotification("Assessment submitted successfully!")}),document.getElementById("btn-import-excel").addEventListener("click",()=>{document.getElementById("fileInput").click()}),document.getElementById("fileInput").addEventListener("change",importFromExcel);const e=document.querySelectorAll('.nav-link[data-bs-toggle="tab"]');e.forEach(t=>{t.addEventListener("click",function(s){s.preventDefault(),e.forEach(e=>e.classList.remove("active")),t.classList.add("active");const a=t.getAttribute("href");document.querySelectorAll(".tab-pane").forEach(e=>e.classList.remove("show","active")),document.querySelector(a).classList.add("show","active")})})});
+    function exportToExcel(){
+        saveProgress();
+        const workbook = XLSX.utils.book_new();
+        const teamInfo = [
+            ['Team Information', ''],
+            ['Team Name', assessmentData.teamInfo.teamName || ''],
+            ['Region', assessmentData.teamInfo.region || ''],
+            ['Country', assessmentData.teamInfo.country || ''],
+            ['Mentor Name', assessmentData.teamInfo.mentorName || ''],
+            [''],
+            ['Headquarters Contact', ''],
+            ['Name', assessmentData.teamInfo.hqName || ''],
+            ['Email', assessmentData.teamInfo.hqEmail || ''],
+            ['Phone', assessmentData.teamInfo.hqPhone || ''],
+            ['Position', assessmentData.teamInfo.hqPosition || ''],
+            [''],
+            ['Operations Contact', ''],
+            ['Name', assessmentData.teamInfo.opsName || ''],
+            ['Email', assessmentData.teamInfo.opsEmail || ''],
+            ['Phone', assessmentData.teamInfo.opsPhone || ''],
+            ['Position', assessmentData.teamInfo.opsPosition || '']
+        ];
+        teamInfo.push(['']);
+        teamInfo.push(['Supported Deployment Modalities', '']);
+        MODALITY_METADATA.forEach(modality => {
+            const supported = assessmentData.teamInfo.deploymentModalities && assessmentData.teamInfo.deploymentModalities[modality.key];
+            teamInfo.push([modality.label, supported ? 'Yes' : 'No']);
+        });
+        const teamSheet = XLSX.utils.aoa_to_sheet(teamInfo);
+        XLSX.utils.book_append_sheet(workbook, teamSheet, 'Team Info');
+
+        const assessmentRows = [['Standard ID', 'Pillar', 'Standard Statement', 'Score', 'Evidence', 'Gaps', 'Actions', 'Comments']];
+        document.querySelectorAll('.compliance-card').forEach(card => {
+            const select = card.querySelector('.score-select');
+            if (!select) return;
+            const sectionKey = select.dataset.section;
+            const itemKey = sectionKey + '-' + select.dataset.item;
+            const titleElement = card.querySelector('.subsection-title');
+            const descElement = card.querySelector('.card-description');
+            const title = titleElement ? titleElement.textContent.trim() : '';
+            const description = descElement ? descElement.textContent.trim() : '';
+            const statement = description ? title + ' — ' + description : title;
+            const evidenceField = card.querySelector('.evidence-input');
+            const gapsField = card.querySelector('.gaps-input');
+            const actionField = card.querySelector('.action-input');
+            const evidence = evidenceField ? evidenceField.value : '';
+            const gaps = gapsField ? gapsField.value : '';
+            const actions = actionField ? actionField.value : '';
+            assessmentRows.push([
+                itemKey,
+                sectionKey,
+                statement,
+                select.value || '',
+                evidence,
+                gaps,
+                actions,
+                (assessmentData.comments && assessmentData.comments[sectionKey + 'Comments']) || ''
+            ]);
+        });
+
+        const assessmentSheet = XLSX.utils.aoa_to_sheet(assessmentRows);
+        XLSX.utils.book_append_sheet(workbook, assessmentSheet, 'HID SCT Assessment');
+        const dateSuffix = (new Date).toISOString().split('T')[0];
+        XLSX.writeFile(workbook, 'HID_SCT_Assessment_' + dateSuffix + '.xlsx');
+        showNotification('Data exported to Excel successfully!');
+    }
+    function importFromExcel(event){
+        const file = event.target.files[0];
+        if (!file) return;
+
+        const reader = new FileReader();
+        reader.onload = function(loadEvent){
+            try {
+                const workbook = XLSX.read(loadEvent.target.result, { type: "binary" });
+                assessmentData = {
+                    teamInfo: { deploymentModalities: { ...DEFAULT_MODALITY_STATE } },
+                    scores: {},
+                    evidence: {},
+                    gaps: {},
+                    actions: {},
+                    comments: {},
+                    summary: {}
+                };
+
+                const sheet = workbook.Sheets["HID SCT Assessment"];
+                if (sheet) {
+                    const rows = XLSX.utils.sheet_to_json(sheet);
+                    for (const row of rows) {
+                        const id = row["Standard ID"];
+                        if (!id) continue;
+                        assessmentData.scores[id] = row.Score;
+                        assessmentData.evidence[id] = row.Evidence;
+                        assessmentData.gaps[id] = row.Gaps;
+                        assessmentData.actions[id] = row.Actions;
+                    }
+                }
+
+                localStorage.setItem("hidSCTAssessment", JSON.stringify(assessmentData));
+                loadSavedData();
+                updateProgress();
+                showNotification("Data imported successfully!");
+            } catch (error) {
+                console.warn('Error importing file', error);
+                showNotification("Error importing file.");
+            }
+        };
+        reader.readAsBinaryString(file);
+    }
+    document.addEventListener("DOMContentLoaded", function () {
+        initializeData();
+
+        document.querySelectorAll("input, textarea, select").forEach(element => {
+            element.addEventListener("change", saveProgress);
+        });
+
+        document.querySelectorAll('.score-select').forEach(select => {
+            updateScoreBadge(select);
+            select.addEventListener('change', function () {
+                updateScoreBadge(select);
+            });
+        });
+
+        document.getElementById("btn-save").addEventListener("click", saveProgress);
+        document.getElementById("btn-export-json").addEventListener("click", () => {
+            saveProgress();
+            const json = JSON.stringify(assessmentData, null, 2);
+            const blob = new Blob([json], { type: "application/json" });
+            const url = URL.createObjectURL(blob);
+            const link = document.createElement("a");
+            link.href = url;
+            link.download = "HID_SCT_Assessment_" + (new Date).toISOString().split("T")[0] + ".json";
+            link.click();
+            URL.revokeObjectURL(url);
+        });
+
+        document.getElementById("btn-export-excel").addEventListener("click", exportToExcel);
+        document.getElementById("btn-submit").addEventListener("click", () => {
+            saveProgress();
+            showNotification("Assessment submitted successfully!");
+        });
+
+        document.getElementById("btn-import-excel").addEventListener("click", () => {
+            document.getElementById("fileInput").click();
+        });
+
+        document.getElementById("fileInput").addEventListener("change", importFromExcel);
+
+        const navLinks = document.querySelectorAll('.nav-link[data-bs-toggle="tab"]');
+        navLinks.forEach(link => {
+            link.addEventListener("click", function (event) {
+                event.preventDefault();
+                navLinks.forEach(item => item.classList.remove("active"));
+                link.classList.add("active");
+                const target = link.getAttribute("href");
+                document.querySelectorAll(".tab-pane").forEach(pane => pane.classList.remove("show", "active"));
+                document.querySelector(target).classList.add("show", "active");
+            });
+        });
+    });
     <\/script>
 <\/body>
 <\/html>


### PR DESCRIPTION
## Summary
- replace template literal IDs inside the generated tool script with string concatenation so the builder script parses correctly
- restore rendering of all accordion sections by preventing syntax errors when building the deployment modality checkbox IDs

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68df97e66068832abd9289e1830e4924