### PR TITLE
Add SCT name field and update generated headings

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
-<html lang="es">
+<html lang="en">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Creador Avanzado de Herramientas de Evaluación HID SCT</title>
+    <title>Advanced HID SCT Assessment Tool Builder</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     <script src="https://cdn.jsdelivr.net/npm/xlsx@0.18.5/dist/xlsx.full.min.js"></script>
@@ -21,13 +21,14 @@
         .modality-option.embedded .modality-icon { background: linear-gradient(135deg, #2563eb, #3b82f6); }
         .modality-option.coupled .modality-icon { background: linear-gradient(135deg, #f59e0b, #fbbf24); }
         .modality-option.self-sustained .modality-icon { background: linear-gradient(135deg, #16a34a, #22c55e); }
-        .modality-option.selected { border-color: transparent; background: linear-gradient(135deg, rgba(79, 70, 229, 0.08), rgba(129, 140, 248, 0.08)); }
+        .modality-option.selected { border-color: transparent; background: linear-gradient(135deg, rgba(79, 70, 229, 0.2), rgba(99, 102, 241, 0.2)); }
         .subsection-item { display: flex; flex-direction: column; gap: 12px; margin-bottom: 20px; padding: 16px; border: 1px solid #e9ecef; border-radius: 12px; background: #fff; }
         .subsection-item .rich-text-editor { flex: 1; }
         .subsection-actions { display: flex; justify-content: flex-end; }
         .subsection-actions .btn { min-width: 120px; }
         .section-content-editor { margin-top: 10px; }
         .section-content-editor .editor-content { min-height: 160px; }
+        .standard-name-group input { font-weight: 600; }
         .weight-input { width: 100px; }
         .accordion-button:not(.collapsed) { color: #fff; background-color: #0d6efd; }
         .accordion-button:not(.collapsed)::after { filter: brightness(0) invert(1); }
@@ -49,13 +50,17 @@
         .builder-modality-columns { display: grid; gap: 12px; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); }
         .builder-modality-columns textarea { min-height: 90px; }
         .builder-deployment-summary { display: inline-flex; align-items: center; gap: 6px; }
+        .author-credit { font-size: 0.9rem; color: #6c757d; margin-top: 8px; }
+        .author-credit a { color: #0d6efd; text-decoration: none; }
+        .author-credit a:hover { text-decoration: underline; }
     </style>
 </head>
 <body>
     <div class="maker-container">
         <div class="maker-header">
-            <h2>🛠️ Creador Avanzado de Herramientas de Evaluación</h2>
-            <p class="text-muted">Personaliza cada aspecto de tu herramienta. El HTML generado será 100% funcional e idéntico al original.</p>
+            <h2>🛠️ Advanced HID SCT Assessment Tool Builder</h2>
+            <p class="text-muted">Customize every part of your tool. The generated HTML will be fully functional and match the original experience.</p>
+            <p class="author-credit">Author by: <a href="mailto:joduzu@gmail.com">Jorge Durand Zurdo</a></p>
         </div>
 
         <div class="card my-4 deployment-modalities-card" id="deployment-modalities-card">
@@ -64,22 +69,30 @@
                 <small class="text-muted">Select the deployment profiles your SCT can support.</small>
             </div>
             <div class="card-body">
-                <div class="deployment-modalities-options" id="deployment-modalities-options"></div>
+                <div class="row g-3 align-items-end">
+                    <div class="col-12 col-md-5 col-lg-4">
+                        <label for="sctName" class="form-label">Name of the SCT</label>
+                        <input type="text" class="form-control" id="sctName" placeholder="e.g. Rehabilitation">
+                    </div>
+                    <div class="col-12 col-md-7 col-lg-8">
+                        <div class="deployment-modalities-options" id="deployment-modalities-options"></div>
+                    </div>
+                </div>
             </div>
         </div>
 
         <div class="card my-4">
-            <div class="card-header"><h5 class="mb-0">Asignar Pesos de Sección (%)</h5></div>
+            <div class="card-header"><h5 class="mb-0">Assign Section Weights (%)</h5></div>
             <div class="card-body">
                 <div class="row" id="weights-container"></div>
-                <div class="alert alert-info mt-3" id="weight-sum-alert">Suma total del peso: <span id="weight-sum">0</span>%. Debe ser 100%.</div>
+                <div class="alert alert-info mt-3" id="weight-sum-alert">Total weight sum: <span id="weight-sum">0</span>%. Must equal 100%.</div>
             </div>
         </div>
 
         <div class="accordion" id="sections-accordion"></div>
 
         <div class="d-grid mt-4">
-            <button class="btn btn-primary btn-lg" id="btn-make"><i class="fas fa-magic me-2"></i>Generar Herramienta HTML Completa</button>
+            <button class="btn btn-primary btn-lg" id="btn-make"><i class="fas fa-magic me-2"></i>Generate Complete HTML Tool</button>
         </div>
     </div>
 
@@ -862,6 +875,10 @@
         ensureDeploymentOverride(sectionKey, itemKey, titleText);
         const subsectionHTML = `
             <div class="subsection-item" data-section="${sectionKey}" data-item-key="${itemKey}" data-default-index="${index}" data-title="${escapeHTML(titleText)}">
+                <div class="standard-name-group mb-2">
+                    <label class="form-label">Standard Name</label>
+                    <input type="text" class="form-control standard-title-input" data-section="${sectionKey}" data-item-key="${itemKey}" value="${escapeHTML(titleText)}" placeholder="Enter the standard title">
+                </div>
                 ${getEditorTemplate(subContent)}
                 ${buildBuilderDeploymentEditor(sectionKey, itemKey, titleText)}
                 <div class="subsection-actions">
@@ -874,6 +891,26 @@
         setupRichTextEditors(newItem);
         setupDeploymentPrefillEditors(newItem);
         updateBuilderModalityEditorsVisibility();
+        const titleInput = newItem.querySelector('.standard-title-input');
+        if (titleInput) {
+            const updateTitle = () => {
+                const defaultIndex = parseInt(newItem.dataset.defaultIndex, 10);
+                const fallbackTitle = Number.isFinite(defaultIndex) ? `Standard ${defaultIndex + 1}` : 'Standard';
+                const value = titleInput.value.trim() || fallbackTitle;
+                newItem.dataset.title = value;
+                const details = newItem.querySelector('.builder-deployment-editor');
+                if (details) {
+                    details.dataset.title = value;
+                }
+                const summaryTitle = newItem.querySelector('.builder-deployment-summary-title');
+                if (summaryTitle) {
+                    summaryTitle.textContent = value;
+                }
+                ensureDeploymentOverride(sectionKey, itemKey, value);
+            };
+            titleInput.addEventListener('input', updateTitle);
+            updateTitle();
+        }
         const removeBtn = newItem.querySelector('.remove-item');
         if (removeBtn) {
             removeBtn.onclick = () => {
@@ -955,7 +992,7 @@
                 'Dead Body Management: EMTs need to be able to manage dead bodies in a way that is dignified, culturally appropriate, safe and according to public health practices.'
             ]
         },
-        'summary': { title: 'SUMMARY', icon: 'fa-file-alt', hasSubsections: false, weight: 0, enabled: true }
+        'summary': { title: 'SUMMARY', icon: 'fa-file-alt', hasSubsections: false, weight: 0, enabled: true, editableContent: true }
     };
 
     let activeEditor = null;
@@ -1019,23 +1056,23 @@
         updateBuilderModalityEditorsVisibility();
     }
 
-    function getEditorTemplate(content = '', placeholder = 'Describe el estándar...') {
+    function getEditorTemplate(content = '', placeholder = 'Describe the standard...') {
         return `
             <div class="rich-text-editor">
                 <div class="editor-toolbar">
-                    <button type="button" class="btn btn-outline-secondary btn-sm format-btn" data-command="bold" title="Negrita"><i class="fas fa-bold"></i></button>
-                    <button type="button" class="btn btn-outline-secondary btn-sm format-btn" data-command="italic" title="Cursiva"><i class="fas fa-italic"></i></button>
-                    <button type="button" class="btn btn-outline-secondary btn-sm format-btn" data-command="underline" title="Subrayado"><i class="fas fa-underline"></i></button>
-                    <button type="button" class="btn btn-outline-secondary btn-sm format-btn" data-command="insertUnorderedList" title="Lista con viñetas"><i class="fas fa-list-ul"></i></button>
-                    <button type="button" class="btn btn-outline-secondary btn-sm format-btn" data-command="insertOrderedList" title="Lista numerada"><i class="fas fa-list-ol"></i></button>
-                    <button type="button" class="btn btn-outline-secondary btn-sm format-btn" data-command="removeFormat" title="Limpiar formato"><i class="fas fa-eraser"></i></button>
+                    <button type="button" class="btn btn-outline-secondary btn-sm format-btn" data-command="bold" title="Bold"><i class="fas fa-bold"></i></button>
+                    <button type="button" class="btn btn-outline-secondary btn-sm format-btn" data-command="italic" title="Italic"><i class="fas fa-italic"></i></button>
+                    <button type="button" class="btn btn-outline-secondary btn-sm format-btn" data-command="underline" title="Underline"><i class="fas fa-underline"></i></button>
+                    <button type="button" class="btn btn-outline-secondary btn-sm format-btn" data-command="insertUnorderedList" title="Bulleted list"><i class="fas fa-list-ul"></i></button>
+                    <button type="button" class="btn btn-outline-secondary btn-sm format-btn" data-command="insertOrderedList" title="Numbered list"><i class="fas fa-list-ol"></i></button>
+                    <button type="button" class="btn btn-outline-secondary btn-sm format-btn" data-command="removeFormat" title="Clear formatting"><i class="fas fa-eraser"></i></button>
                 </div>
                 <div class="editor-content form-control" contenteditable="true" data-placeholder="${placeholder}">${content}</div>
             </div>
         `;
     }
 
-    function buildDeploymentModalitiesCardHTML(selectedKeys = []) {
+    function buildDeploymentModalitiesCardHTML(selectedKeys = [], sctNameValue = '') {
         const selectedSet = new Set(selectedKeys);
         const optionsHTML = DEPLOYMENT_MODALITIES.map(modality => {
             const isSelected = selectedSet.has(modality.key);
@@ -1050,6 +1087,8 @@
         `;
         }).join('');
 
+        const escapedName = escapeHTML(sctNameValue);
+
         return `
             <div class="card section-card deployment-modalities-card">
                 <div class="section-header">
@@ -1057,10 +1096,38 @@
                     <p class="text-muted small mb-0">Select the deployment profiles your SCT can support.</p>
                 </div>
                 <div class="card-body">
-                    <div class="deployment-modality-grid">
-                        ${optionsHTML}
+                    <div class="row g-3 align-items-end">
+                        <div class="col-12 col-md-5 col-lg-4">
+                            <label for="sctName" class="form-label">Name of the SCT</label>
+                            <input type="text" class="form-control" id="sctName" value="${escapedName}" placeholder="e.g. Rehabilitation">
+                        </div>
+                        <div class="col-12 col-md-7 col-lg-8">
+                            <div class="deployment-modality-grid">
+                                ${optionsHTML}
+                            </div>
+                        </div>
                     </div>
                 </div>
+            </div>
+        `;
+    }
+
+    function buildDeploymentSummaryBannerHTML(selectedKeys = [], headingText = 'HID SCT Tool') {
+        const selectedModalities = DEPLOYMENT_MODALITIES.filter(modality => selectedKeys.includes(modality.key));
+        const pillsHTML = selectedModalities.map(modality => `
+            <span class="deployment-summary-pill ${modality.accentClass || ''}">
+                <i class="fas ${modality.icon || 'fa-clipboard'}"></i>
+                ${escapeHTML(modality.label)}
+            </span>
+        `).join('');
+        const hiddenClass = selectedModalities.length ? '' : ' d-none';
+        return `
+            <div class="deployment-summary-banner${hiddenClass}" id="deploymentSummaryBanner">
+                <div class="deployment-summary-info">
+                    <h2 class="deployment-summary-title" id="deploymentSummaryTitle">${escapeHTML(headingText)}</h2>
+                    <p class="deployment-summary-subtitle" id="deploymentSummarySubtitle">Supported deployment modalities</p>
+                </div>
+                <div class="deployment-summary-pill-group" id="deploymentSummaryPills">${pillsHTML}</div>
             </div>
         `;
     }
@@ -1149,16 +1216,16 @@
 
             let sectionBody = '';
             if (config.hasSubsections) {
-                sectionBody = `<h5>Estándares / Subsecciones (HTML y formato permitido)</h5>
+                sectionBody = `<h5>Standards / Subsections (HTML allowed)</h5>
                 <div id="subsections-${key}" class="subsections-container"></div>
-                <button class="btn btn-outline-success mt-2 add-item" data-section="${key}"><i class="fas fa-plus me-2"></i>Añadir Estándar</button>`;
+                <button class="btn btn-outline-success mt-2 add-item" data-section="${key}"><i class="fas fa-plus me-2"></i>Add Standard</button>`;
             } else if (config.editableContent) {
-                sectionBody = `<h5>Contenido de la pestaña (HTML y formato permitido)</h5>
+                sectionBody = `<h5>Tab content (HTML allowed)</h5>
                 <div class="section-content-editor" data-section="${key}">
-                    ${getEditorTemplate(SECTION_CONTENT[key] || '', 'Edita el contenido de esta pestaña...')}
+                    ${getEditorTemplate(SECTION_CONTENT[key] || '', 'Edit the content for this tab...')}
                 </div>`;
             } else {
-                sectionBody = `<div class="alert alert-light">El contenido de esta sección es fijo y se insertará automáticamente en la herramienta final.</div>`;
+                sectionBody = `<div class="alert alert-light">This section's content is fixed and will be inserted automatically in the final tool.</div>`;
             }
 
             const sectionHTML = `
@@ -1166,10 +1233,10 @@
                     <h2 class="accordion-header">
                         <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapse-${key}">
                             <div class="section-header-controls w-100">
-                                <span class="me-auto">Configurar: ${config.title}</span>
+                                <span class="me-auto">Configure: ${config.title}</span>
                                 <div class="form-check form-switch">
                                     <input class="form-check-input section-enable-switch" type="checkbox" data-key="${key}" ${config.enabled ? 'checked' : ''}>
-                                    <label class="form-check-label">Habilitar</label>
+                                    <label class="form-check-label">Enable</label>
                                 </div>
                             </div>
                         </button>
@@ -1177,7 +1244,7 @@
                     <div id="collapse-${key}" class="accordion-collapse collapse" data-bs-parent="#sections-accordion">
                         <div class="accordion-body">
                             <div class="mb-3">
-                                <label class="form-label">Título de la Sección</label>
+                                <label class="form-label">Section Title</label>
                                 <input type="text" class="form-control section-title-input" data-key="${key}" value="${config.title}">
                             </div>
                             ${sectionBody}
@@ -1303,328 +1370,12 @@
         });
     }
 
-    function setupRichTextEditors(root = document) {
-        root.querySelectorAll('.editor-content').forEach(editor => {
-            const updatePlaceholderState = () => {
-                const text = editor.innerText.trim();
-                editor.classList.toggle('empty', text.length === 0);
-            };
-            updatePlaceholderState();
-            editor.addEventListener('input', updatePlaceholderState);
-            editor.addEventListener('focus', () => {
-                activeEditor = editor;
-                editor.classList.add('focus');
-                storeSelection(editor);
-            });
-            editor.addEventListener('blur', () => {
-                editor.classList.remove('focus');
-                if (activeEditor === editor) {
-                    activeEditor = null;
-                    savedRange = null;
-                }
-            });
-            editor.addEventListener('keyup', () => storeSelection(editor));
-            editor.addEventListener('mouseup', () => storeSelection(editor));
-            editor.addEventListener('input', () => storeSelection(editor));
-            editor._updatePlaceholder = updatePlaceholderState;
-        });
-        root.querySelectorAll('.format-btn').forEach(btn => {
-            btn.onmousedown = e => {
-                e.preventDefault();
-                const command = btn.dataset.command;
-                const value = btn.dataset.value || null;
-                const container = btn.closest('.subsection-item') || btn.closest('.section-content-editor') || btn.closest('.rich-text-editor');
-                const editor = container ? container.querySelector('.editor-content') : null;
-                if (editor) {
-                    if (activeEditor !== editor) {
-                        activeEditor = editor;
-                    }
-                    restoreSelection(editor);
-                    document.execCommand(command, false, value);
-                    if (typeof editor._updatePlaceholder === 'function') {
-                        editor._updatePlaceholder();
-                    }
-                    storeSelection(editor);
-                }
-            };
-        });
-    }
 
-    function setupRichTextEditors(root = document) {
-        root.querySelectorAll('.editor-content').forEach(editor => {
-            const updatePlaceholderState = () => {
-                const text = editor.innerText.trim();
-                editor.classList.toggle('empty', text.length === 0);
-            };
-            updatePlaceholderState();
-            editor.addEventListener('input', updatePlaceholderState);
-            editor.addEventListener('focus', () => {
-                activeEditor = editor;
-                editor.classList.add('focus');
-                storeSelection(editor);
-            });
-            editor.addEventListener('blur', () => {
-                editor.classList.remove('focus');
-                if (activeEditor === editor) {
-                    activeEditor = null;
-                    savedRange = null;
-                }
-            });
-            editor.addEventListener('keyup', () => storeSelection(editor));
-            editor.addEventListener('mouseup', () => storeSelection(editor));
-            editor.addEventListener('input', () => storeSelection(editor));
-            editor._updatePlaceholder = updatePlaceholderState;
-        });
-        root.querySelectorAll('.format-btn').forEach(btn => {
-            btn.onmousedown = e => {
-                e.preventDefault();
-                const command = btn.dataset.command;
-                const value = btn.dataset.value || null;
-                const container = btn.closest('.subsection-item') || btn.closest('.section-content-editor') || btn.closest('.rich-text-editor');
-                const editor = container ? container.querySelector('.editor-content') : null;
-                if (editor) {
-                    if (activeEditor !== editor) {
-                        activeEditor = editor;
-                    }
-                    restoreSelection(editor);
-                    document.execCommand(command, false, value);
-                    if (typeof editor._updatePlaceholder === 'function') {
-                        editor._updatePlaceholder();
-                    }
-                    storeSelection(editor);
-                }
-            };
-        });
-    }
 
-    function setupRichTextEditors(root = document) {
-        root.querySelectorAll('.editor-content').forEach(editor => {
-            const updatePlaceholderState = () => {
-                const text = editor.innerText.trim();
-                editor.classList.toggle('empty', text.length === 0);
-            };
-            updatePlaceholderState();
-            editor.addEventListener('input', updatePlaceholderState);
-            editor.addEventListener('focus', () => {
-                activeEditor = editor;
-                editor.classList.add('focus');
-                storeSelection(editor);
-            });
-            editor.addEventListener('blur', () => {
-                editor.classList.remove('focus');
-                if (activeEditor === editor) {
-                    activeEditor = null;
-                    savedRange = null;
-                }
-            });
-            editor.addEventListener('keyup', () => storeSelection(editor));
-            editor.addEventListener('mouseup', () => storeSelection(editor));
-            editor.addEventListener('input', () => storeSelection(editor));
-            editor._updatePlaceholder = updatePlaceholderState;
-        });
-        root.querySelectorAll('.format-btn').forEach(btn => {
-            btn.onmousedown = e => {
-                e.preventDefault();
-                const command = btn.dataset.command;
-                const value = btn.dataset.value || null;
-                const container = btn.closest('.subsection-item') || btn.closest('.section-content-editor') || btn.closest('.rich-text-editor');
-                const editor = container ? container.querySelector('.editor-content') : null;
-                if (editor) {
-                    if (activeEditor !== editor) {
-                        activeEditor = editor;
-                    }
-                    restoreSelection(editor);
-                    document.execCommand(command, false, value);
-                    if (typeof editor._updatePlaceholder === 'function') {
-                        editor._updatePlaceholder();
-                    }
-                    storeSelection(editor);
-                }
-            };
-        });
-    }
 
-    function setupRichTextEditors(root = document) {
-        root.querySelectorAll('.editor-content').forEach(editor => {
-            const updatePlaceholderState = () => {
-                const text = editor.innerText.trim();
-                editor.classList.toggle('empty', text.length === 0);
-            };
-            updatePlaceholderState();
-            editor.addEventListener('input', updatePlaceholderState);
-            editor.addEventListener('focus', () => {
-                activeEditor = editor;
-                editor.classList.add('focus');
-                storeSelection(editor);
-            });
-            editor.addEventListener('blur', () => {
-                editor.classList.remove('focus');
-                if (activeEditor === editor) {
-                    activeEditor = null;
-                    savedRange = null;
-                }
-            });
-            editor.addEventListener('keyup', () => storeSelection(editor));
-            editor.addEventListener('mouseup', () => storeSelection(editor));
-            editor.addEventListener('input', () => storeSelection(editor));
-            editor._updatePlaceholder = updatePlaceholderState;
-        });
-        root.querySelectorAll('.format-btn').forEach(btn => {
-            btn.onmousedown = e => {
-                e.preventDefault();
-                const command = btn.dataset.command;
-                const value = btn.dataset.value || null;
-                const container = btn.closest('.subsection-item') || btn.closest('.section-content-editor') || btn.closest('.rich-text-editor');
-                const editor = container ? container.querySelector('.editor-content') : null;
-                if (editor) {
-                    if (activeEditor !== editor) {
-                        activeEditor = editor;
-                    }
-                    restoreSelection(editor);
-                    document.execCommand(command, false, value);
-                    if (typeof editor._updatePlaceholder === 'function') {
-                        editor._updatePlaceholder();
-                    }
-                    storeSelection(editor);
-                }
-            };
-        });
-    }
 
-    function setupRichTextEditors(root = document) {
-        root.querySelectorAll('.editor-content').forEach(editor => {
-            const updatePlaceholderState = () => {
-                const text = editor.innerText.trim();
-                editor.classList.toggle('empty', text.length === 0);
-            };
-            updatePlaceholderState();
-            editor.addEventListener('input', updatePlaceholderState);
-            editor.addEventListener('focus', () => {
-                activeEditor = editor;
-                editor.classList.add('focus');
-                storeSelection(editor);
-            });
-            editor.addEventListener('blur', () => {
-                editor.classList.remove('focus');
-                if (activeEditor === editor) {
-                    activeEditor = null;
-                    savedRange = null;
-                }
-            });
-            editor.addEventListener('keyup', () => storeSelection(editor));
-            editor.addEventListener('mouseup', () => storeSelection(editor));
-            editor.addEventListener('input', () => storeSelection(editor));
-            editor._updatePlaceholder = updatePlaceholderState;
-        });
-        root.querySelectorAll('.format-btn').forEach(btn => {
-            btn.onmousedown = e => {
-                e.preventDefault();
-                const command = btn.dataset.command;
-                const value = btn.dataset.value || null;
-                const container = btn.closest('.subsection-item') || btn.closest('.section-content-editor') || btn.closest('.rich-text-editor');
-                const editor = container ? container.querySelector('.editor-content') : null;
-                if (editor) {
-                    if (activeEditor !== editor) {
-                        activeEditor = editor;
-                    }
-                    restoreSelection(editor);
-                    document.execCommand(command, false, value);
-                    editor._updatePlaceholder?.();
-                    storeSelection(editor);
-                }
-            };
-        });
-    }
 
-    function setupRichTextEditors(root = document) {
-        root.querySelectorAll('.editor-content').forEach(editor => {
-            const updatePlaceholderState = () => {
-                const text = editor.innerText.trim();
-                editor.classList.toggle('empty', text.length === 0);
-            };
-            updatePlaceholderState();
-            editor.addEventListener('input', updatePlaceholderState);
-            editor.addEventListener('focus', () => {
-                activeEditor = editor;
-                editor.classList.add('focus');
-                storeSelection(editor);
-            });
-            editor.addEventListener('blur', () => {
-                editor.classList.remove('focus');
-                if (activeEditor === editor) {
-                    activeEditor = null;
-                    savedRange = null;
-                }
-            });
-            editor.addEventListener('keyup', () => storeSelection(editor));
-            editor.addEventListener('mouseup', () => storeSelection(editor));
-            editor.addEventListener('input', () => storeSelection(editor));
-            editor._updatePlaceholder = updatePlaceholderState;
-        });
-        root.querySelectorAll('.format-btn').forEach(btn => {
-            btn.onmousedown = e => {
-                e.preventDefault();
-                const command = btn.dataset.command;
-                const value = btn.dataset.value || null;
-                const container = btn.closest('.subsection-item') || btn.closest('.section-content-editor') || btn.closest('.rich-text-editor');
-                const editor = container ? container.querySelector('.editor-content') : null;
-                if (editor) {
-                    if (activeEditor !== editor) {
-                        activeEditor = editor;
-                    }
-                    restoreSelection(editor);
-                    document.execCommand(command, false, value);
-                    editor._updatePlaceholder?.();
-                    storeSelection(editor);
-                }
-            };
-        });
-    }
 
-    function setupRichTextEditors(root = document) {
-        root.querySelectorAll('.editor-content').forEach(editor => {
-            const updatePlaceholderState = () => {
-                const text = editor.innerText.trim();
-                editor.classList.toggle('empty', text.length === 0);
-            };
-            updatePlaceholderState();
-            editor.addEventListener('input', updatePlaceholderState);
-            editor.addEventListener('focus', () => {
-                activeEditor = editor;
-                editor.classList.add('focus');
-                storeSelection(editor);
-            });
-            editor.addEventListener('blur', () => {
-                editor.classList.remove('focus');
-                if (activeEditor === editor) {
-                    activeEditor = null;
-                    savedRange = null;
-                }
-            });
-            editor.addEventListener('keyup', () => storeSelection(editor));
-            editor.addEventListener('mouseup', () => storeSelection(editor));
-            editor.addEventListener('input', () => storeSelection(editor));
-            editor._updatePlaceholder = updatePlaceholderState;
-        });
-        root.querySelectorAll('.format-btn').forEach(btn => {
-            btn.onmousedown = e => {
-                e.preventDefault();
-                const command = btn.dataset.command;
-                const value = btn.dataset.value || null;
-                const container = btn.closest('.subsection-item') || btn.closest('.section-content-editor') || btn.closest('.rich-text-editor');
-                const editor = container ? container.querySelector('.editor-content') : null;
-                if (editor) {
-                    if (activeEditor !== editor) {
-                        activeEditor = editor;
-                    }
-                    restoreSelection(editor);
-                    document.execCommand(command, false, value);
-                    editor._updatePlaceholder?.();
-                    storeSelection(editor);
-                }
-            };
-        });
-    }
 
     function updateWeightSum() {
         const sum = Array.from(document.querySelectorAll('.weight-input:not(:disabled)')).reduce((acc, input) => acc + (parseInt(input.value) || 0), 0);
@@ -1654,14 +1405,14 @@
                 finalConfig[key].subsections = items.map((item, index) => {
                     const editor = item.querySelector('.editor-content');
                     const content = editor ? editor.innerHTML.trim() : '';
-                    if (!content) {
-                        return null;
-                    }
                     const itemKey = item.dataset.itemKey || generateSubsectionKey(key);
-                    const titleText = item.dataset.title || extractTitleTextFromHTML(content, index);
+                    let titleText = item.dataset.title || extractTitleTextFromHTML(content, index);
+                    if (!titleText) {
+                        titleText = `Standard ${index + 1}`;
+                    }
                     ensureDeploymentOverride(key, itemKey, titleText);
                     return { content, itemKey, titleText };
-                }).filter(Boolean);
+                });
             }
             if (finalConfig[key].editableContent) {
                 const editor = document.querySelector(`#accordion-item-${key} .section-content-editor .editor-content`);
@@ -1672,8 +1423,14 @@
         const selectedModalities = Array.from(document.querySelectorAll('.deployment-modality-checkbox'))
             .filter(cb => cb.checked)
             .map(cb => cb.dataset.key);
-        const deploymentModalitiesCardHTML = buildDeploymentModalitiesCardHTML(selectedModalities);
+        const sctNameField = document.getElementById('sctName');
+        const rawSctName = sctNameField ? sctNameField.value.trim() : '';
+        const headingText = rawSctName
+            ? (rawSctName.toLowerCase().endsWith('sct tool') ? rawSctName : rawSctName + ' SCT Tool')
+            : 'HID SCT Tool';
+        const deploymentModalitiesCardHTML = buildDeploymentModalitiesCardHTML(selectedModalities, rawSctName);
         const deploymentModalityDetailsHTML = buildDeploymentModalityDetailsHTML(selectedModalities);
+        const deploymentSummaryBannerHTML = buildDeploymentSummaryBannerHTML(selectedModalities, headingText);
         const defaultModalityState = {};
         DEPLOYMENT_MODALITIES.forEach(modality => {
             defaultModalityState[modality.key] = selectedModalities.includes(modality.key);
@@ -1861,7 +1618,7 @@
 
         const fullHTML = `
 <!DOCTYPE html>
-<html lang="es">
+<html lang="en">
 <head>
     <meta charset="UTF-8"><meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>HID SCT Self-Assessment Grid - Customized</title>
@@ -1933,6 +1690,92 @@
             background: #f8f9ff;
         }
 
+        .author-credit {
+            font-size: 0.9rem;
+            color: #475569;
+            margin-bottom: 16px;
+        }
+
+        .author-credit a {
+            color: #4338ca;
+            text-decoration: none;
+            font-weight: 600;
+        }
+
+        .author-credit a:hover {
+            text-decoration: underline;
+        }
+
+        .deployment-summary-banner {
+            display: flex;
+            flex-wrap: wrap;
+            justify-content: space-between;
+            align-items: center;
+            background: linear-gradient(135deg, #312e81, #6366f1);
+            color: #ffffff;
+            padding: 24px;
+            border-radius: 18px;
+            margin-bottom: 24px;
+            box-shadow: 0 12px 32px rgba(79, 70, 229, 0.24);
+            gap: 16px;
+        }
+
+        .deployment-summary-info {
+            display: flex;
+            flex-direction: column;
+            gap: 4px;
+        }
+
+        .deployment-summary-title {
+            font-size: 1.75rem;
+            margin: 0 0 6px;
+            font-weight: 700;
+        }
+
+        .deployment-summary-subtitle {
+            margin: 0;
+            font-size: 0.95rem;
+            opacity: 0.85;
+        }
+
+        .deployment-summary-pill-group {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 10px;
+        }
+
+        .deployment-summary-pill {
+            display: inline-flex;
+            align-items: center;
+            gap: 8px;
+            padding: 10px 16px;
+            border-radius: 999px;
+            background: rgba(255, 255, 255, 0.92);
+            color: #1f2937;
+            font-weight: 600;
+            box-shadow: 0 6px 18px rgba(15, 23, 42, 0.12);
+            transition: transform 0.2s ease;
+        }
+
+        .deployment-summary-pill i {
+            font-size: 0.9rem;
+        }
+
+        .deployment-summary-pill.embedded {
+            background: #dbeafe;
+            color: #1d4ed8;
+        }
+
+        .deployment-summary-pill.coupled {
+            background: #fef3c7;
+            color: #b45309;
+        }
+
+        .deployment-summary-pill.self-sustained {
+            background: #dcfce7;
+            color: #15803d;
+        }
+
         .progress-sidebar {
             background-color: #ffffff;
             height: 100vh;
@@ -1995,7 +1838,7 @@
         }
 
         .modality-pill.selected {
-            background: linear-gradient(135deg, rgba(79, 70, 229, 0.12), rgba(59, 130, 246, 0.12));
+            background: linear-gradient(135deg, rgba(79, 70, 229, 0.24), rgba(59, 130, 246, 0.24));
             border-color: transparent;
             box-shadow: 0 10px 24px rgba(59, 130, 246, 0.18);
         }
@@ -2197,6 +2040,290 @@
             box-shadow: 0 12px 30px rgba(34, 197, 94, 0.3);
             z-index: 1000;
             animation: slideIn 0.3s ease;
+        }
+
+        .btn-report {
+            background: linear-gradient(135deg, #7c3aed, #6366f1);
+            border: none;
+            color: #ffffff;
+            font-weight: 600;
+            padding: 0.75rem 2.2rem;
+            box-shadow: 0 18px 32px rgba(99, 102, 241, 0.25);
+            transition: transform 0.2s ease, box-shadow 0.2s ease;
+        }
+
+        .btn-report:hover,
+        .btn-report:focus {
+            color: #ffffff;
+            transform: translateY(-1px);
+            box-shadow: 0 22px 38px rgba(99, 102, 241, 0.35);
+        }
+
+        .btn-report:disabled {
+            opacity: 0.7;
+            transform: none;
+            box-shadow: none;
+        }
+
+        .pdf-report-root {
+            position: fixed;
+            top: -10000px;
+            left: -10000px;
+            width: 1024px;
+            padding: 48px;
+            background: #eef2ff;
+            color: #1f2937;
+            font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+            z-index: -1;
+        }
+
+        .pdf-report {
+            background: #ffffff;
+            border-radius: 28px;
+            overflow: hidden;
+            box-shadow: 0 24px 60px rgba(79, 70, 229, 0.18);
+        }
+
+        .pdf-header {
+            background: linear-gradient(135deg, #5b21b6 0%, #4338ca 100%);
+            color: #ffffff;
+            text-align: center;
+            padding: 48px 40px 40px;
+        }
+
+        .pdf-header h1 {
+            margin-bottom: 0.35rem;
+            font-weight: 700;
+            letter-spacing: 0.04em;
+        }
+
+        .pdf-header .pdf-subtitle {
+            font-size: 1.1rem;
+            opacity: 0.85;
+            margin-bottom: 0.25rem;
+        }
+
+        .pdf-header .pdf-date {
+            font-size: 0.95rem;
+            opacity: 0.75;
+        }
+
+        .pdf-body {
+            padding: 40px;
+            display: flex;
+            flex-direction: column;
+            gap: 32px;
+        }
+
+        .pdf-body section h3 {
+            font-weight: 700;
+            margin-bottom: 1.25rem;
+            color: #312e81;
+        }
+
+        .pdf-info-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+            gap: 18px;
+        }
+
+        .pdf-info-item {
+            background: #f8f9ff;
+            border-radius: 18px;
+            padding: 18px;
+            box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.7), 0 10px 28px rgba(79, 70, 229, 0.1);
+            display: flex;
+            flex-direction: column;
+            gap: 8px;
+        }
+
+        .pdf-info-label {
+            text-transform: uppercase;
+            font-size: 0.75rem;
+            letter-spacing: 0.08em;
+            color: #6366f1;
+        }
+
+        .pdf-info-value {
+            font-size: 1.05rem;
+            font-weight: 600;
+            color: #1f2937;
+        }
+
+        .pdf-overview-cards {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+            gap: 18px;
+            margin-bottom: 24px;
+        }
+
+        .pdf-summary-card {
+            background: linear-gradient(135deg, rgba(129, 140, 248, 0.18), rgba(99, 102, 241, 0.12));
+            border-radius: 20px;
+            padding: 20px 24px;
+            box-shadow: 0 18px 34px rgba(79, 70, 229, 0.14);
+            display: flex;
+            flex-direction: column;
+            gap: 10px;
+        }
+
+        .pdf-summary-label {
+            font-size: 0.85rem;
+            letter-spacing: 0.06em;
+            text-transform: uppercase;
+            color: #4338ca;
+        }
+
+        .pdf-summary-value {
+            font-size: 2.25rem;
+            font-weight: 700;
+            color: #1f1b4b;
+        }
+
+        .pdf-summary-table {
+            width: 100%;
+            border-collapse: collapse;
+            background: #ffffff;
+            border-radius: 18px;
+            overflow: hidden;
+            box-shadow: 0 16px 34px rgba(30, 64, 175, 0.12);
+        }
+
+        .pdf-summary-table th,
+        .pdf-summary-table td {
+            padding: 16px 18px;
+            text-align: left;
+        }
+
+        .pdf-summary-table thead {
+            background: #eef2ff;
+            color: #3730a3;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            font-size: 0.85rem;
+        }
+
+        .pdf-summary-table tbody tr:nth-child(even) {
+            background: #f8faff;
+        }
+
+        .pdf-summary-total td {
+            font-weight: 700;
+            background: #ede9fe;
+        }
+
+        .pdf-details {
+            display: flex;
+            flex-direction: column;
+            gap: 28px;
+        }
+
+        .pdf-section-block {
+            background: #f5f7ff;
+            border-radius: 22px;
+            padding: 26px;
+            box-shadow: 0 16px 32px rgba(76, 29, 149, 0.12);
+        }
+
+        .pdf-section-block h3 {
+            margin-bottom: 18px;
+            color: #312e81;
+        }
+
+        .pdf-detail-card {
+            background: #ffffff;
+            border-radius: 18px;
+            padding: 24px;
+            box-shadow: 0 20px 40px rgba(79, 70, 229, 0.12);
+            display: flex;
+            flex-direction: column;
+            gap: 18px;
+            margin-bottom: 18px;
+        }
+
+        .pdf-detail-card:last-child {
+            margin-bottom: 0;
+        }
+
+        .pdf-detail-card-header {
+            display: flex;
+            justify-content: space-between;
+            gap: 18px;
+            align-items: flex-start;
+        }
+
+        .pdf-detail-card-header h4 {
+            margin: 0 0 6px;
+            font-size: 1.1rem;
+            color: #1f2937;
+        }
+
+        .pdf-detail-card-header p {
+            margin: 0;
+            color: #4b5563;
+            line-height: 1.6;
+        }
+
+        .pdf-detail-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+            gap: 20px;
+        }
+
+        .pdf-detail-grid h5 {
+            text-transform: uppercase;
+            font-size: 0.75rem;
+            letter-spacing: 0.08em;
+            color: #6366f1;
+            margin-bottom: 8px;
+        }
+
+        .pdf-detail-grid p {
+            margin: 0;
+            color: #374151;
+            line-height: 1.6;
+        }
+
+        .pdf-status-pill {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            border-radius: 999px;
+            padding: 6px 16px;
+            font-size: 0.75rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.08em;
+        }
+
+        .status-not-started {
+            background: rgba(148, 163, 184, 0.28);
+            color: #1f2937;
+        }
+
+        .status-initial {
+            background: rgba(253, 230, 138, 0.35);
+            color: #b45309;
+        }
+
+        .status-in-progress {
+            background: rgba(96, 165, 250, 0.28);
+            color: #1d4ed8;
+        }
+
+        .status-completed {
+            background: rgba(134, 239, 172, 0.3);
+            color: #047857;
+        }
+
+        .status-na {
+            background: rgba(209, 213, 219, 0.35);
+            color: #374151;
+        }
+
+        .pdf-empty {
+            color: #9ca3af;
+            font-style: italic;
         }
 
         .progress-sidebar-table {
@@ -2559,12 +2686,25 @@
             .main-content {
                 max-height: none;
             }
+
+            .deployment-summary-banner {
+                align-items: flex-start;
+            }
         }
 
         @media (max-width: 768px) {
             .sidebar {
                 height: auto;
                 position: relative;
+            }
+
+            .deployment-summary-banner {
+                flex-direction: column;
+                gap: 12px;
+            }
+
+            .deployment-summary-pill-group {
+                width: 100%;
             }
 
             .section-banner {
@@ -2603,21 +2743,53 @@
                 width: 100%;
             }
         }
-    <\/style>
-<\/head>
+    </style>
+</head>
 <body>
     <div class="app-container"><div class="row g-0">
-        <div class="col-lg-2"><div class="sidebar"><h4 class="text-center mb-4">HID SCT Assessment</h4><ul class="nav flex-column">${sidebarLinks}</ul><div class="mt-4 p-3"><div class="progress-bar-container"><div class="progress-bar bg-success" id="overallProgressBar" style="width:0%"></div></div><p class="mb-1">Overall Completion</p><h5 class="text-center" id="overallProgressText">0%</h5></div></div></div>
-        <div class="col-lg-8"><div class="main-content"><div class="tab-content">${tabPanes}</div><div class="d-flex justify-content-between mt-4"><div><button class="btn btn-outline-secondary" id="btn-import-excel"><i class="fas fa-upload me-2"></i>Import Excel</button><button class="btn btn-outline-secondary" id="btn-export-json"><i class="fas fa-download me-2"></i>Export JSON</button></div><div><button class="btn btn-outline-primary me-2" id="btn-save"><i class="fas fa-save me-2"></i>Save Draft</button><button class="btn btn-outline-info me-2" id="btn-export-excel"><i class="fas fa-file-excel me-2"></i>Export to Excel</button><button class="btn btn-success" id="btn-submit"><i class="fas fa-check-circle me-2"></i>Submit Assessment</button></div></div></div></div>
+        <div class="col-lg-2"><div class="sidebar"><h4 class="text-center mb-4" id="sidebarSctTitle">${escapeHTML(headingText)}</h4><ul class="nav flex-column">${sidebarLinks}</ul><div class="mt-4 p-3"><div class="progress-bar-container"><div class="progress-bar bg-success" id="overallProgressBar" style="width:0%"></div></div><p class="mb-1">Overall Completion</p><h5 class="text-center" id="overallProgressText">0%</h5></div></div></div>
+        <div class="col-lg-8"><div class="main-content"><div class="author-credit">Author by: <a href="mailto:joduzu@gmail.com">Jorge Durand Zurdo</a></div>${deploymentSummaryBannerHTML}<div class="tab-content">${tabPanes}</div><div class="d-flex justify-content-between mt-4"><div><button class="btn btn-outline-secondary" id="btn-import-excel"><i class="fas fa-upload me-2"></i>Import Excel</button><button class="btn btn-outline-secondary" id="btn-export-json"><i class="fas fa-download me-2"></i>Export JSON</button></div><div><button class="btn btn-outline-primary me-2" id="btn-save"><i class="fas fa-save me-2"></i>Save Draft</button><button class="btn btn-outline-info me-2" id="btn-export-excel"><i class="fas fa-file-excel me-2"></i>Export to Excel</button><button class="btn btn-success" id="btn-submit"><i class="fas fa-check-circle me-2"></i>Submit Assessment</button></div></div><div class="text-end mt-3"><button class="btn btn-report" id="btn-generate-pdf"><i class="fas fa-file-pdf me-2"></i>Generate PDF Report</button></div></div></div>
         <div class="col-lg-2"><div class="progress-sidebar"><h5 class="mb-3">Progress Overview</h5><div class="progress-bar-container mb-3"><div class="progress-bar bg-success" id="sidebarProgressBar" style="width:0%"></div></div><p class="mb-1">Overall Completion</p><h5 class="text-center mb-4" id="sidebarProgressText">0%</h5><table class="progress-sidebar-table"><thead><tr><th>Section</th><th>Status</th><th>%</th></tr></thead><tbody id="progressSidebarBody"></tbody></table></div></div>
     </div></div>
     <input type="file" id="fileInput" class="file-input" accept=".xlsx, .xls">
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"><\/script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"><\/script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"><\/script>
     <script>
     const SECTIONS_WITH_WEIGHT = ${JSON.stringify(weightsData)};
     const MODALITY_METADATA = ${modalityMetadataJSON};
     const DEFAULT_MODALITY_STATE = ${defaultModalityStateJSON};
+    const SCORE_DESCRIPTORS = {
+        '0': { label: 'Not Started', className: 'status-not-started' },
+        '1': { label: 'Initial', className: 'status-initial' },
+        '2': { label: 'In Progress', className: 'status-in-progress' },
+        '3': { label: 'Completed', className: 'status-completed' },
+        'NA': { label: 'Not Applicable', className: 'status-na' }
+    };
+    const DEFAULT_SCT_NAME = ${JSON.stringify(rawSctName)};
+    const DEFAULT_SUMMARY_TITLE = 'HID SCT Tool';
     let assessmentData={teamInfo:{},scores:{},evidence:{},gaps:{},actions:{},comments:{},summary:{},deploymentRequirements:{}};
+    function safeGetItem(key){
+        try {
+            if (typeof window !== 'undefined' && window.localStorage) {
+                return window.localStorage.getItem(key);
+            }
+        } catch (error) {
+            console.warn('Unable to read localStorage key', key, error);
+        }
+        return null;
+    }
+    function safeSetItem(key, value){
+        try {
+            if (typeof window !== 'undefined' && window.localStorage) {
+                window.localStorage.setItem(key, value);
+                return true;
+            }
+        } catch (error) {
+            console.warn('Unable to write localStorage key', key, error);
+        }
+        return false;
+    }
     function getFieldValue(id){
         const element = document.getElementById(id);
         return element ? element.value : '';
@@ -2626,6 +2798,47 @@
         const element = document.getElementById(id);
         if (element){
             element.value = value;
+        }
+    }
+    function deriveSctTitle(rawValue){
+        const trimmed = (rawValue || '').toString().trim();
+        if (!trimmed) {
+            return DEFAULT_SUMMARY_TITLE;
+        }
+        return trimmed.toLowerCase().endsWith('sct tool') ? trimmed : trimmed + ' SCT Tool';
+    }
+    function renderDeploymentSummary(modalityState = DEFAULT_MODALITY_STATE){
+        const pillsContainer = document.getElementById('deploymentSummaryPills');
+        const titleEl = document.getElementById('deploymentSummaryTitle');
+        const sidebarTitle = document.getElementById('sidebarSctTitle');
+        const banner = document.getElementById('deploymentSummaryBanner');
+        const state = { ...DEFAULT_MODALITY_STATE, ...(modalityState || {}) };
+        const activeModalities = MODALITY_METADATA.filter(modality => state[modality.key]);
+        if (pillsContainer) {
+            pillsContainer.innerHTML = '';
+            activeModalities.forEach(modality => {
+                const pill = document.createElement('span');
+                pill.className = 'deployment-summary-pill ' + (modality.accentClass || '');
+                pill.innerHTML = '<i class="fas ' + (modality.icon || 'fa-clipboard') + '"></i> ' + modality.label;
+                pillsContainer.appendChild(pill);
+            });
+        }
+        const currentName = (getFieldValue('sctName') || '').trim();
+        const storedSctName = assessmentData.teamInfo && typeof assessmentData.teamInfo.sctName === 'string'
+            ? assessmentData.teamInfo.sctName
+            : '';
+        const fallbackTeamName = assessmentData.teamInfo && typeof assessmentData.teamInfo.teamName === 'string'
+            ? assessmentData.teamInfo.teamName
+            : '';
+        const derivedTitle = deriveSctTitle(currentName || storedSctName || fallbackTeamName || DEFAULT_SCT_NAME || '');
+        if (titleEl) {
+            titleEl.textContent = derivedTitle;
+        }
+        if (sidebarTitle) {
+            sidebarTitle.textContent = derivedTitle;
+        }
+        if (banner) {
+            banner.classList.toggle('d-none', activeModalities.length === 0);
         }
     }
     function toggleModalityDetails(){
@@ -2641,7 +2854,7 @@
         });
     }
     function initializeData(){
-        const stored = localStorage.getItem("hidSCTAssessment");
+        const stored = safeGetItem("hidSCTAssessment");
         if (stored) {
             try {
                 const parsed = JSON.parse(stored);
@@ -2657,11 +2870,14 @@
                 };
             } catch (error) {
                 console.warn('Failed to parse saved assessment data', error);
-                assessmentData = {teamInfo:{},scores:{},evidence:{},gaps:{},actions:{},comments:{},summary:{},deploymentRequirements:{}};
+                assessmentData = {teamInfo:{ sctName: DEFAULT_SCT_NAME || '', deploymentModalities: { ...DEFAULT_MODALITY_STATE } },scores:{},evidence:{},gaps:{},actions:{},comments:{},summary:{},deploymentRequirements:{}};
             }
         }
 
         assessmentData.teamInfo = assessmentData.teamInfo || {};
+        if (assessmentData.teamInfo.sctName === undefined && DEFAULT_SCT_NAME) {
+            assessmentData.teamInfo.sctName = DEFAULT_SCT_NAME;
+        }
         if (!assessmentData.teamInfo.deploymentModalities) {
             assessmentData.teamInfo.deploymentModalities = { ...DEFAULT_MODALITY_STATE };
         }
@@ -2671,6 +2887,9 @@
     }
     function loadSavedData(){
         assessmentData.teamInfo = assessmentData.teamInfo || {};
+        if (assessmentData.teamInfo.sctName === undefined && DEFAULT_SCT_NAME) {
+            assessmentData.teamInfo.sctName = DEFAULT_SCT_NAME;
+        }
         const modalityState = { ...DEFAULT_MODALITY_STATE, ...(assessmentData.teamInfo.deploymentModalities || {}) };
 
         MODALITY_METADATA.forEach(modality => {
@@ -2747,8 +2966,18 @@
                 setFieldValue(id, assessmentData.summary[id]);
             });
         }
+        renderDeploymentSummary(modalityState);
     }
-    function saveProgress(){
+    function saveProgress(arg){
+        if (arg && typeof arg.preventDefault === 'function') {
+            arg.preventDefault();
+        }
+        let shouldNotify = true;
+        if (typeof arg === 'boolean') {
+            shouldNotify = arg;
+        } else if (arg && typeof arg === 'object' && !('type' in arg) && Object.prototype.hasOwnProperty.call(arg, 'showNotification')) {
+            shouldNotify = arg.showNotification !== false;
+        }
         const modalityState = { ...DEFAULT_MODALITY_STATE };
         MODALITY_METADATA.forEach(modality => {
             const checkbox = document.getElementById('modality-' + modality.key);
@@ -2764,6 +2993,7 @@
         toggleModalityDetails();
 
         assessmentData.teamInfo = {
+            sctName: getFieldValue('sctName'),
             teamName: getFieldValue('teamName'),
             region: getFieldValue('region'),
             country: getFieldValue('country'),
@@ -2778,6 +3008,7 @@
             opsPosition: getFieldValue('opsPosition'),
             deploymentModalities: modalityState
         };
+        renderDeploymentSummary(modalityState);
 
         assessmentData.scores = {};
         assessmentData.evidence = {};
@@ -2841,11 +3072,112 @@
             mentorAssignment: getFieldValue('mentorAssignment')
         };
 
-        localStorage.setItem('hidSCTAssessment', JSON.stringify(assessmentData));
-        showNotification('Progress saved successfully!');
+        safeSetItem('hidSCTAssessment', JSON.stringify(assessmentData));
+        if (shouldNotify) {
+            showNotification('Progress saved successfully!');
+        }
         updateProgress();
+        return assessmentData;
     }
     function showNotification(e){const t=document.createElement("div");t.className="notification",t.textContent=e,document.body.appendChild(t),setTimeout(()=>{t.style.animation="fadeOut .3s ease",setTimeout(()=>t.remove(),300)},3e3)}
+    function escapeHtmlForPdf(text){
+        if (text === null || text === undefined) {
+            return '';
+        }
+        return text.toString().replace(/[&<>"']/g, function(match){
+            switch (match) {
+                case '&': return '&amp;';
+                case '<': return '&lt;';
+                case '>': return '&gt;';
+                case '"': return '&quot;';
+                case "'": return '&#39;';
+                default: return match;
+            }
+        });
+    }
+    function formatPdfValue(value, fallback = 'Not provided'){
+        const trimmed = (value || '').toString().trim();
+        if (!trimmed) {
+            return '<span class="pdf-empty">' + escapeHtmlForPdf(fallback) + '</span>';
+        }
+        return escapeHtmlForPdf(trimmed);
+    }
+    function formatPdfParagraph(value, fallback){
+        const trimmed = (value || '').toString().trim();
+        if (!trimmed) {
+            return fallback ? '<span class="pdf-empty">' + escapeHtmlForPdf(fallback) + '</span>' : '';
+        }
+        return escapeHtmlForPdf(trimmed).replace(/\\n/g, '<br>');
+    }
+    function calculateSectionSnapshots(){
+        const sectionScores = {};
+        SECTIONS_WITH_WEIGHT.forEach(section => {
+            sectionScores[section.section] = { name: section.name, weight: section.weight, total: 0, max: 0 };
+        });
+        Object.entries(assessmentData.scores || {}).forEach(([key, value]) => {
+            const [sectionKey] = key.split('-');
+            if (!sectionKey || !sectionScores[sectionKey]) {
+                return;
+            }
+            if (value === '' || value === 'NA') {
+                return;
+            }
+            const numeric = parseInt(value, 10);
+            if (!Number.isNaN(numeric)) {
+                sectionScores[sectionKey].total += numeric;
+                sectionScores[sectionKey].max += 3;
+            }
+        });
+        return SECTIONS_WITH_WEIGHT.map(section => {
+            const entry = sectionScores[section.section] || { total: 0, max: 0, weight: section.weight, name: section.name };
+            const percent = entry.max > 0 ? Math.round((entry.total / entry.max) * 100) : 0;
+            let status = 'Not Started';
+            let badgeClass = 'status-not-started';
+            if (percent >= 100) {
+                status = 'Completed';
+                badgeClass = 'status-completed';
+            } else if (percent > 0) {
+                status = 'In Progress';
+                badgeClass = 'status-in-progress';
+            }
+            return {
+                key: section.section,
+                name: section.name,
+                weight: section.weight,
+                percent,
+                status,
+                badgeClass,
+                hasProgress: entry.max > 0
+            };
+        });
+    }
+    function collectSectionDetails(){
+        const sectionDetails = {};
+        document.querySelectorAll('.compliance-card').forEach(card => {
+            const select = card.querySelector('.score-select');
+            if (!select) return;
+            const sectionKey = select.dataset.section;
+            const itemId = select.dataset.item;
+            if (!sectionKey || !itemId) return;
+            const descriptor = SCORE_DESCRIPTORS[select.value] || SCORE_DESCRIPTORS['0'];
+            const itemKey = sectionKey + '-' + itemId;
+            if (!sectionDetails[sectionKey]) {
+                sectionDetails[sectionKey] = [];
+            }
+            const titleElement = card.querySelector('.subsection-title');
+            const descriptionElement = card.querySelector('.card-description');
+            sectionDetails[sectionKey].push({
+                title: titleElement ? titleElement.textContent.trim() : '',
+                description: descriptionElement ? descriptionElement.innerText.trim() : '',
+                statusLabel: descriptor.label,
+                statusClass: descriptor.className,
+                evidence: (assessmentData.evidence && assessmentData.evidence[itemKey]) || '',
+                gaps: (assessmentData.gaps && assessmentData.gaps[itemKey]) || '',
+                actions: (assessmentData.actions && assessmentData.actions[itemKey]) || ''
+            });
+        });
+        return sectionDetails;
+    }
     function updateScoreBadge(select){
         const value = select.value;
         select.className = 'form-select score-select compliance-score';
@@ -2853,7 +3185,181 @@
             select.classList.add('score-' + value);
         }
     }
-    function updateProgress(){let e=0,t=0,s=0;const a={};SECTIONS_WITH_WEIGHT.forEach(e=>{a[e.section]={score:0,maxScore:0}});let o=0,n=0;document.querySelectorAll(".score-select").forEach(e=>{const t=e.dataset.section;a[t]&&(o++,""!==e.value&&(n++,"NA"!==e.value&&(a[t].score+=parseInt(e.value),a[t].maxScore+=3)))});let i=0;SECTIONS_WITH_WEIGHT.forEach(s=>{const o=a[s.section];let n=0;o.maxScore>0&&(n=Math.round(o.score/o.maxScore*100));const c=document.getElementById(s.section+"Score");c&&(c.textContent=n+"% Complete"),e+=s.weight,t+=s.weight*n/100}),i=e>0?Math.round(t/e*100):0,s=Object.values(a).filter(e=>e.maxScore>0).length,document.getElementById("overallProgressBar").style.width=i+"%",document.getElementById("overallProgressText").textContent=i+"%",document.getElementById("sidebarProgressBar").style.width=i+"%",document.getElementById("sidebarProgressText").textContent=i+"%",document.getElementById("completedSections").textContent=s+"/"+SECTIONS_WITH_WEIGHT.length,document.getElementById("overallScore").textContent=i+"%",document.getElementById("lastUpdated").textContent=(new Date).toLocaleDateString();const c=document.getElementById("progressTableBody"),d=document.getElementById("progressSidebarBody");c.innerHTML="",d.innerHTML="";let r=0,l=0;SECTIONS_WITH_WEIGHT.forEach(e=>{const t=a[e.section];let s=0;t.maxScore>0&&(s=Math.round(t.score/t.maxScore*100));const o=0===s?"Not Started":s<100?"In Progress":"Completed",n="Completed"===o?"bg-success":"In Progress"===o?"bg-warning":"bg-secondary";r+=e.weight,l+=e.weight*s/100,c.innerHTML+=\`<tr><td>\${e.name}</td><td>\${e.weight}%</td><td><span class="badge \${n}">\${o}</span></td><td>\${s}%</td></tr>\`,d.innerHTML+=\`<tr><td>\${e.name.split(" ")[0]}</td><td><span class="badge \${n}">\${o}</span></td><td>\${s}%</td></tr>\`});const m=r>0?Math.round(l/r*100):0;c.innerHTML+=\`<tr class="table-primary fw-bold"><td>TOTAL</td><td>\${r}%</td><td></td><td>\${m}%</td></tr>\`}
+    function updateProgress(){
+        const sectionScores = {};
+        SECTIONS_WITH_WEIGHT.forEach(section => {
+            sectionScores[section.section] = { score: 0, maxScore: 0, percent: 0 };
+        });
+
+        document.querySelectorAll('.score-select').forEach(select => {
+            const sectionKey = select.dataset.section;
+            if (!sectionKey || !sectionScores[sectionKey]) {
+                return;
+            }
+
+            if (select.value !== '' && select.value !== 'NA') {
+                const numeric = parseInt(select.value, 10);
+                if (!Number.isNaN(numeric)) {
+                    sectionScores[sectionKey].score += numeric;
+                    sectionScores[sectionKey].maxScore += 3;
+                }
+            }
+        });
+
+        let weightedTotal = 0;
+        let totalWeight = 0;
+        let sectionsWithRecordedScores = 0;
+
+        SECTIONS_WITH_WEIGHT.forEach(section => {
+            const sectionData = sectionScores[section.section];
+            if (!sectionData) {
+                return;
+            }
+
+            if (sectionData.maxScore > 0) {
+                sectionData.percent = Math.round((sectionData.score / sectionData.maxScore) * 100);
+                sectionsWithRecordedScores += 1;
+            }
+
+            const banner = document.getElementById(section.section + 'Score');
+            if (banner) {
+                banner.textContent = sectionData.percent + '% Complete';
+            }
+
+            totalWeight += section.weight;
+            weightedTotal += (section.weight * sectionData.percent) / 100;
+        });
+
+        const overallPercent = totalWeight > 0 ? Math.round((weightedTotal / totalWeight) * 100) : 0;
+
+        const overallProgressBar = document.getElementById('overallProgressBar');
+        if (overallProgressBar) {
+            overallProgressBar.style.width = overallPercent + '%';
+        }
+        const overallProgressText = document.getElementById('overallProgressText');
+        if (overallProgressText) {
+            overallProgressText.textContent = overallPercent + '%';
+        }
+        const sidebarProgressBar = document.getElementById('sidebarProgressBar');
+        if (sidebarProgressBar) {
+            sidebarProgressBar.style.width = overallPercent + '%';
+        }
+        const sidebarProgressText = document.getElementById('sidebarProgressText');
+        if (sidebarProgressText) {
+            sidebarProgressText.textContent = overallPercent + '%';
+        }
+
+        const completedSectionsEl = document.getElementById('completedSections');
+        if (completedSectionsEl) {
+            completedSectionsEl.textContent = sectionsWithRecordedScores + '/' + SECTIONS_WITH_WEIGHT.length;
+        }
+        const overallScoreEl = document.getElementById('overallScore');
+        if (overallScoreEl) {
+            overallScoreEl.textContent = overallPercent + '%';
+        }
+        const lastUpdatedEl = document.getElementById('lastUpdated');
+        if (lastUpdatedEl) {
+            lastUpdatedEl.textContent = (new Date).toLocaleDateString();
+        }
+
+        const tableBody = document.getElementById('progressTableBody');
+        const sidebarBody = document.getElementById('progressSidebarBody');
+        if (tableBody) {
+            tableBody.innerHTML = '';
+        }
+        if (sidebarBody) {
+            sidebarBody.innerHTML = '';
+        }
+
+        let listedWeight = 0;
+        let listedWeightedPercent = 0;
+
+        SECTIONS_WITH_WEIGHT.forEach(section => {
+            const sectionData = sectionScores[section.section];
+            if (!sectionData) {
+                return;
+            }
+
+            const percent = sectionData.percent || 0;
+            const status = percent === 0 ? 'Not Started' : percent < 100 ? 'In Progress' : 'Completed';
+            const badgeClass = status === 'Completed' ? 'bg-success' : status === 'In Progress' ? 'bg-warning' : 'bg-secondary';
+
+            listedWeight += section.weight;
+            listedWeightedPercent += (section.weight * percent) / 100;
+
+            if (tableBody) {
+                tableBody.insertAdjacentHTML(
+                    'beforeend',
+                    '<tr><td>' + section.name + '</td><td>' + section.weight + '%</td><td><span class="badge ' + badgeClass + '">' + status + '</span></td><td>' + percent + '%</td></tr>'
+                );
+            }
+
+            if (sidebarBody) {
+                const shortName = section.name.split(' ')[0];
+                sidebarBody.insertAdjacentHTML(
+                    'beforeend',
+                    '<tr><td>' + shortName + '</td><td><span class="badge ' + badgeClass + '">' + status + '</span></td><td>' + percent + '%</td></tr>'
+                );
+            }
+        });
+
+        if (tableBody) {
+            const totalPercent = listedWeight > 0 ? Math.round((listedWeightedPercent / listedWeight) * 100) : 0;
+            tableBody.insertAdjacentHTML(
+                'beforeend',
+                '<tr class="table-primary fw-bold"><td>TOTAL</td><td>' + listedWeight + '%</td><td></td><td>' + totalPercent + '%</td></tr>'
+            );
+        }
+    }
+    async function generatePdfReport(){
+        const data = saveProgress(false);
+        if (!window.html2canvas || !window.jspdf || !window.jspdf.jsPDF) {
+            throw new Error('Missing PDF dependencies');
+        }
+        const snapshots = calculateSectionSnapshots();
+        const sectionDetails = collectSectionDetails();
+        const totalWeight = snapshots.reduce((sum, section) => sum + section.weight, 0);
+        const weightedProgress = snapshots.reduce((sum, section) => sum + (section.percent * section.weight / 100), 0);
+        const overallPercent = totalWeight > 0 ? Math.round((weightedProgress / totalWeight) * 100) : 0;
+        const sectionsWithProgress = snapshots.filter(section => section.hasProgress).length;
+        const generatedDate = new Date();
+        const formattedDate = generatedDate.toLocaleDateString(undefined, { year: 'numeric', month: 'long', day: 'numeric' });
+        const summaryRows = snapshots.map(section => '<tr><td>' + escapeHtmlForPdf(section.name) + '</td><td>' + section.weight + '%</td><td><span class="pdf-status-pill ' + section.badgeClass + '">' + section.status + '</span></td><td>' + section.percent + '%</td></tr>').join('');
+        const summaryTableHtml = '<table class="pdf-summary-table"><thead><tr><th>Section</th><th>Weight</th><th>Status</th><th>Progress</th></tr></thead><tbody>' + summaryRows + '<tr class="pdf-summary-total"><td>Total</td><td>' + totalWeight + '%</td><td></td><td>' + overallPercent + '%</td></tr></tbody></table>';
+        const detailsHtml = snapshots
+            .filter(section => (sectionDetails[section.key] || []).length > 0)
+            .map(section => {
+                const cardsHtml = sectionDetails[section.key].map(card => '<div class="pdf-detail-card"><div class="pdf-detail-card-header"><div><h4>' + escapeHtmlForPdf(card.title || 'Untitled Standard') + '</h4>' + (card.description ? '<p>' + formatPdfParagraph(card.description) + '</p>' : '') + '</div><span class="pdf-status-pill ' + card.statusClass + '">' + card.statusLabel + '</span></div><div class="pdf-detail-grid"><div><h5>Evidence</h5><p>' + formatPdfParagraph(card.evidence, 'No evidence provided') + '</p></div><div><h5>Gaps</h5><p>' + formatPdfParagraph(card.gaps, 'No gaps identified') + '</p></div><div><h5>Actions</h5><p>' + formatPdfParagraph(card.actions, 'No actions planned') + '</p></div></div></div>').join('');
+                return '<div class="pdf-section-block"><h3>' + escapeHtmlForPdf(section.name) + '</h3>' + cardsHtml + '</div>';
+            }).join('') || '<p class="pdf-empty">No assessment data captured yet.</p>';
+        const teamInfo = data && data.teamInfo ? data.teamInfo : {};
+        const reportRoot = document.createElement('div');
+        reportRoot.className = 'pdf-report-root';
+        reportRoot.innerHTML = '<div class="pdf-report"><div class="pdf-header"><h1>HID SCT Assessment Report</h1><p class="pdf-subtitle">Minimum Standards Assessment</p><p class="pdf-date">Generated on ' + escapeHtmlForPdf(formattedDate) + '</p></div><div class="pdf-body"><section class="pdf-team-info"><h3>Team Information</h3><div class="pdf-info-grid"><div class="pdf-info-item"><span class="pdf-info-label">Team Name</span><span class="pdf-info-value">' + formatPdfValue(teamInfo.teamName) + '</span></div><div class="pdf-info-item"><span class="pdf-info-label">Region</span><span class="pdf-info-value">' + formatPdfValue(teamInfo.region) + '</span></div><div class="pdf-info-item"><span class="pdf-info-label">Country</span><span class="pdf-info-value">' + formatPdfValue(teamInfo.country) + '</span></div><div class="pdf-info-item"><span class="pdf-info-label">Mentor</span><span class="pdf-info-value">' + formatPdfValue(teamInfo.mentorName) + '</span></div></div></section><section class="pdf-overview"><h3>Overall Progress Summary</h3><div class="pdf-overview-cards"><div class="pdf-summary-card"><span class="pdf-summary-label">Overall Progress</span><span class="pdf-summary-value">' + overallPercent + '%</span></div><div class="pdf-summary-card"><span class="pdf-summary-label">Sections Completed</span><span class="pdf-summary-value">' + sectionsWithProgress + '/' + snapshots.length + '</span></div></div>' + summaryTableHtml + '</section><section class="pdf-details"><h3>Detailed Assessment Results</h3>' + detailsHtml + '</section></div></div>';
+        document.body.appendChild(reportRoot);
+        await new Promise(resolve => requestAnimationFrame(resolve));
+        const canvas = await html2canvas(reportRoot, { scale: 2, useCORS: true, backgroundColor: '#eef2ff' });
+        const imgData = canvas.toDataURL('image/png');
+        const pdf = new window.jspdf.jsPDF('p', 'mm', 'a4');
+        const pageWidth = pdf.internal.pageSize.getWidth();
+        const pageHeight = pdf.internal.pageSize.getHeight();
+        const imgWidth = pageWidth;
+        const imgHeight = canvas.height * imgWidth / canvas.width;
+        let heightLeft = imgHeight;
+        let position = 0;
+        pdf.addImage(imgData, 'PNG', 0, position, imgWidth, imgHeight);
+        heightLeft -= pageHeight;
+        while (heightLeft > 0) {
+            position = heightLeft - imgHeight;
+            pdf.addPage();
+            pdf.addImage(imgData, 'PNG', 0, position, imgWidth, imgHeight);
+            heightLeft -= pageHeight;
+        }
+        const dateSuffix = generatedDate.toISOString().split('T')[0];
+        pdf.save('HID_SCT_Assessment_Report_' + dateSuffix + '.pdf');
+        document.body.removeChild(reportRoot);
+        showNotification('PDF report generated successfully!');
+    }
     function exportToExcel(){
         saveProgress();
         const workbook = XLSX.utils.book_new();
@@ -2922,8 +3428,8 @@
                         mitigationParts.push(label + ': ' + entry.mitigation.trim());
                     }
                 });
-                deploymentRequirementsText = requirementParts.join('\n\n');
-                deploymentMitigationsText = mitigationParts.join('\n\n');
+                deploymentRequirementsText = requirementParts.join('\\n\\n');
+                deploymentMitigationsText = mitigationParts.join('\\n\\n');
             }
             assessmentRows.push([
                 itemKey,
@@ -2954,7 +3460,7 @@
             try {
                 const workbook = XLSX.read(loadEvent.target.result, { type: "binary" });
                 assessmentData = {
-                    teamInfo: { deploymentModalities: { ...DEFAULT_MODALITY_STATE } },
+                    teamInfo: { sctName: DEFAULT_SCT_NAME || '', deploymentModalities: { ...DEFAULT_MODALITY_STATE } },
                     scores: {},
                     evidence: {},
                     gaps: {},
@@ -2977,7 +3483,7 @@
                     }
                 }
 
-                localStorage.setItem("hidSCTAssessment", JSON.stringify(assessmentData));
+                safeSetItem("hidSCTAssessment", JSON.stringify(assessmentData));
                 loadSavedData();
                 updateProgress();
                 showNotification("Data imported successfully!");
@@ -2990,6 +3496,22 @@
     }
     document.addEventListener("DOMContentLoaded", function () {
         initializeData();
+
+        ['sctName', 'teamName'].forEach(fieldId => {
+            const input = document.getElementById(fieldId);
+            if (input) {
+                input.addEventListener('input', () => {
+                    const currentState = { ...DEFAULT_MODALITY_STATE };
+                    MODALITY_METADATA.forEach(modality => {
+                        const checkbox = document.getElementById('modality-' + modality.key);
+                        if (checkbox) {
+                            currentState[modality.key] = checkbox.checked;
+                        }
+                    });
+                    renderDeploymentSummary(currentState);
+                });
+            }
+        });
 
         document.querySelectorAll("input, textarea, select").forEach(element => {
             element.addEventListener("change", saveProgress);
@@ -3021,6 +3543,27 @@
             showNotification("Assessment submitted successfully!");
         });
 
+        const pdfButton = document.getElementById("btn-generate-pdf");
+        if (pdfButton) {
+            const originalHtml = pdfButton.innerHTML;
+            pdfButton.addEventListener("click", async () => {
+                if (pdfButton.disabled) {
+                    return;
+                }
+                pdfButton.disabled = true;
+                pdfButton.innerHTML = '<span class="spinner-border spinner-border-sm me-2" role="status" aria-hidden="true"></span>Generating PDF...';
+                try {
+                    await generatePdfReport();
+                } catch (error) {
+                    console.warn('Failed to generate PDF report', error);
+                    showNotification('Unable to generate PDF report. Please try again.');
+                } finally {
+                    pdfButton.disabled = false;
+                    pdfButton.innerHTML = originalHtml;
+                }
+            });
+        }
+
         document.getElementById("btn-import-excel").addEventListener("click", () => {
             document.getElementById("fileInput").click();
         });
@@ -3040,8 +3583,8 @@
         });
     });
     <\/script>
-<\/body>
-<\/html>
+</body>
+</html>
 `;
         const blob = new Blob([fullHTML], { type: 'text/html' });
         const url = URL.createObjectURL(blob);


### PR DESCRIPTION
## Summary
- add a "Name of the SCT" input next to the deployment modality selector and carry it into the generated layout
- compute the SCT tool heading during generation and reuse it for the hero banner and sidebar title
- persist the SCT name in the exported script, updating summary rendering, defaults, and saves to honor the new field

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e2e4be6700832ab50af0d216d60f6b